### PR TITLE
replaced 3 deprecated generic calls to Create()

### DIFF
--- a/src/CustomLayouts/Controls/CarouselLayout.cs
+++ b/src/CustomLayouts/Controls/CarouselLayout.cs
@@ -59,17 +59,14 @@ namespace CustomLayouts.Controls
 			_layingOutChildren = false;
 		}
 
-		public static readonly BindableProperty SelectedIndexProperty =
-			BindableProperty.Create<CarouselLayout, int> (
-				carousel => carousel.SelectedIndex,
-				0,
-				BindingMode.TwoWay,
-				propertyChanged: (bindable, oldValue, newValue) => {
-				((CarouselLayout)bindable).UpdateSelectedItem ();
-			}
-			);
+        public static readonly BindableProperty SelectedIndexProperty =
+            BindableProperty.Create("SelectedIndex", typeof(int), typeof(CarouselLayout), 0, BindingMode.TwoWay,
+                propertyChanged: (bindable, oldValue, newValue) => {
+                    ((CarouselLayout)bindable).UpdateSelectedItem();
+                }
+            );
 
-		public int SelectedIndex {
+        public int SelectedIndex {
 			get {
 				return (int)GetValue (SelectedIndexProperty);
 			}
@@ -88,19 +85,17 @@ namespace CustomLayouts.Controls
 			SelectedItem = SelectedIndex > -1 ? Children [SelectedIndex].BindingContext : null;
 		}
 
-		public static readonly BindableProperty ItemsSourceProperty =
-			BindableProperty.Create<CarouselLayout, IList> (
-				view => view.ItemsSource,
-				null,
-				propertyChanging: (bindableObject, oldValue, newValue) => {
-				((CarouselLayout)bindableObject).ItemsSourceChanging ();
-			},
-				propertyChanged: (bindableObject, oldValue, newValue) => {
-				((CarouselLayout)bindableObject).ItemsSourceChanged ();
-			}
-			);
+        public static readonly BindableProperty ItemsSourceProperty =
+            BindableProperty.Create("ItemsSource", typeof(IList), typeof(CarouselLayout), null,
+                propertyChanging: (bindableObject, oldValue, newValue) => {
+                    ((CarouselLayout)bindableObject).ItemsSourceChanging();
+                },
+                propertyChanged: (bindableObject, oldValue, newValue) => {
+                    ((CarouselLayout)bindableObject).ItemsSourceChanged();
+                }
+            );
 
-		public IList ItemsSource {
+        public IList ItemsSource {
 			get {
 				return (IList)GetValue (ItemsSourceProperty);
 			}
@@ -134,17 +129,14 @@ namespace CustomLayouts.Controls
 			set;
 		}
 
-		public static readonly BindableProperty SelectedItemProperty = 
-			BindableProperty.Create<CarouselLayout, object> (
-				view => view.SelectedItem,
-				null,
-				BindingMode.TwoWay,
-				propertyChanged: (bindable, oldValue, newValue) => {
-				((CarouselLayout)bindable).UpdateSelectedIndex ();
-			}
-			);
+        public static readonly BindableProperty SelectedItemProperty =
+            BindableProperty.Create("SelectedItem", typeof(object), typeof(CarouselLayout), null, BindingMode.TwoWay,
+                propertyChanged: (bindable, oldValue, newValue) => {
+                    ((CarouselLayout)bindable).UpdateSelectedIndex();
+                }
+            );
 
-		public object SelectedItem {
+        public object SelectedItem {
 			get {
 				return GetValue (SelectedItemProperty);
 			}


### PR DESCRIPTION
Chris, this contains only one file, CarouselLayout.cs.  The change is to update 3 generic calls to Create() because they are being deprecated.  In the project that I am using your carousel, the runtime version is v4.030319 for all of the Xamarin.Forms*, I got this warning "BindableProperty.Create<... is obsolete: Generic version of Create() are no longer supported and deprecated. They will be removed soon.".

I hope this is makes sense to add to your project.

The next pull request I am planning to complete is the vertical scroll option.  Again, I will keep it as simple as possible.

thx,

Pat Bradley
