### PR TITLE
Updated to Xamarin.Forms 2.3.4

### DIFF
--- a/src/CustomLayouts/PagerIndicatorTabs.cs
+++ b/src/CustomLayouts/PagerIndicatorTabs.cs
@@ -6,153 +6,167 @@ using System.Reflection;
 
 namespace CustomLayouts
 {
-	public class PagerIndicatorTabs : Grid
-	{
-		int _selectedIndex;
+    public class PagerIndicatorTabs : Grid
+    {
+        int _selectedIndex;
 
-		public Color DotColor { get; set; }
-		public double DotSize { get; set; }
+        public Color DotColor { get; set; }
+        public double DotSize { get; set; }
 
-		public PagerIndicatorTabs()
-		{
-			HorizontalOptions = LayoutOptions.CenterAndExpand;
-			VerticalOptions = LayoutOptions.Center;
-			DotColor = Color.Black;
-			Device.OnPlatform(iOS: () => BackgroundColor = Color.Gray);
+        public PagerIndicatorTabs()
+        {
+            HorizontalOptions = LayoutOptions.CenterAndExpand;
+            VerticalOptions = LayoutOptions.Center;
+            DotColor = Color.Black;
+            switch (Device.RuntimePlatform)
+            {
+                case Device.iOS:
+                    BackgroundColor = Color.Gray;
+                    break;
+            }
 
-			var assembly = typeof(PagerIndicatorTabs).GetTypeInfo().Assembly;
-			foreach (var res in assembly.GetManifestResourceNames())
-				System.Diagnostics.Debug.WriteLine("found resource: " + res);
-		}
+            var assembly = typeof(PagerIndicatorTabs).GetTypeInfo().Assembly;
+            foreach (var res in assembly.GetManifestResourceNames())
+                System.Diagnostics.Debug.WriteLine("found resource: " + res);
+        }
 
-		void CreateTabs()
-		{
+        void CreateTabs()
+        {
 
-			if(Children != null && Children.Count > 0) Children.Clear();
+            if (Children != null && Children.Count > 0) Children.Clear();
 
-			foreach(var item in ItemsSource)
-			{
+            foreach (var item in ItemsSource)
+            {
 
-				var index = Children.Count;
-				var tab = new StackLayout {
-					Orientation = StackOrientation.Vertical,
-					HorizontalOptions = LayoutOptions.Center,
-					VerticalOptions = LayoutOptions.Center,
-					Padding = new Thickness(7),
-				};
-				Device.OnPlatform(
-					iOS: () =>
-					{
-						tab.Children.Add(new Image { Source = "pin.png", HeightRequest = 20 });
-						tab.Children.Add(new Label { Text = "Tab " + (index + 1), FontSize = 11 });
-					},					
-					Android: () =>
-					{
-						tab.Children.Add(new Image { Source = "pin.png", HeightRequest = 25 });
-					}
-				);
-				var tgr = new TapGestureRecognizer();
-				tgr.Command = new Command(() =>
-				{
-					SelectedItem = ItemsSource[index];
-				});
-				tab.GestureRecognizers.Add(tgr);
-				Children.Add(tab, index, 0);
-			}
-		}
+                var index = Children.Count;
+                var tab = new StackLayout
+                {
+                    Orientation = StackOrientation.Vertical,
+                    HorizontalOptions = LayoutOptions.Center,
+                    VerticalOptions = LayoutOptions.Center,
+                    Padding = new Thickness(7),
+                };
+                switch (Device.RuntimePlatform)
+                {
+                    case Device.iOS:
+                        tab.Children.Add(new Image { Source = "pin.png", HeightRequest = 20 });
+                        tab.Children.Add(new Label { Text = "Tab " + (index + 1), FontSize = 11 });
+                        break;
 
-		public static BindableProperty ItemsSourceProperty =
-			BindableProperty.Create(
-				nameof(ItemsSource),
-				typeof(IList),
-				typeof(PagerIndicatorTabs),
-				null,
-				BindingMode.OneWay,
-				propertyChanging: (bindable, oldValue, newValue) =>
-				{
-					((PagerIndicatorTabs)bindable).ItemsSourceChanging();
-				},
-				propertyChanged: (bindable, oldValue, newValue) =>
-				{
-					((PagerIndicatorTabs)bindable).ItemsSourceChanged();
-				}
-		);
+                    case Device.Android:
+                        tab.Children.Add(new Image { Source = "pin.png", HeightRequest = 25 });
+                        break;
+                }
 
-		public IList ItemsSource {
-			get {
-				return (IList)GetValue(ItemsSourceProperty);
-			}
-			set {
-				SetValue (ItemsSourceProperty, value);
-			}
-		}
+                var tgr = new TapGestureRecognizer();
+                tgr.Command = new Command(() =>
+                {
+                    SelectedItem = ItemsSource[index];
+                });
+                tab.GestureRecognizers.Add(tgr);
+                Children.Add(tab, index, 0);
+            }
+        }
 
-		public static BindableProperty SelectedItemProperty =
-			BindableProperty.Create(
-				nameof(SelectedItem),
-				typeof(object),
-				typeof(PagerIndicatorTabs),
-				null,
-				BindingMode.TwoWay,
-				propertyChanged: (bindable, oldValue, newValue) =>
-				{
-					((PagerIndicatorTabs)bindable).SelectedItemChanged();
-				}
-		);
+        public static BindableProperty ItemsSourceProperty =
+            BindableProperty.Create(
+                nameof(ItemsSource),
+                typeof(IList),
+                typeof(PagerIndicatorTabs),
+                null,
+                BindingMode.OneWay,
+                propertyChanging: (bindable, oldValue, newValue) =>
+                {
+                    ((PagerIndicatorTabs)bindable).ItemsSourceChanging();
+                },
+                propertyChanged: (bindable, oldValue, newValue) =>
+                {
+                    ((PagerIndicatorTabs)bindable).ItemsSourceChanged();
+                }
+        );
 
-		public object SelectedItem {
-			get {
-				return GetValue (SelectedItemProperty);
-			}
-			set {
-				SetValue (SelectedItemProperty, value);
-			}
-		}
+        public IList ItemsSource
+        {
+            get
+            {
+                return (IList)GetValue(ItemsSourceProperty);
+            }
+            set
+            {
+                SetValue(ItemsSourceProperty, value);
+            }
+        }
 
-		void ItemsSourceChanging ()
-		{
-			if (ItemsSource != null)
-				_selectedIndex = ItemsSource.IndexOf (SelectedItem);
-		}
+        public static BindableProperty SelectedItemProperty =
+            BindableProperty.Create(
+                nameof(SelectedItem),
+                typeof(object),
+                typeof(PagerIndicatorTabs),
+                null,
+                BindingMode.TwoWay,
+                propertyChanged: (bindable, oldValue, newValue) =>
+                {
+                    ((PagerIndicatorTabs)bindable).SelectedItemChanged();
+                }
+        );
 
-		void ItemsSourceChanged ()
-		{
-			if (ItemsSource == null) return;
+        public object SelectedItem
+        {
+            get
+            {
+                return GetValue(SelectedItemProperty);
+            }
+            set
+            {
+                SetValue(SelectedItemProperty, value);
+            }
+        }
 
-			this.ColumnDefinitions.Clear();
-			foreach(var item in ItemsSource)
-			{
-				this.ColumnDefinitions.Add(new ColumnDefinition() { Width = new GridLength(1, GridUnitType.Star) });
-			}
+        void ItemsSourceChanging()
+        {
+            if (ItemsSource != null)
+                _selectedIndex = ItemsSource.IndexOf(SelectedItem);
+        }
 
-			CreateTabs();
-		}
+        void ItemsSourceChanged()
+        {
+            if (ItemsSource == null) return;
 
-		void SelectedItemChanged () {
+            this.ColumnDefinitions.Clear();
+            foreach (var item in ItemsSource)
+            {
+                this.ColumnDefinitions.Add(new ColumnDefinition() { Width = new GridLength(1, GridUnitType.Star) });
+            }
 
-			var selectedIndex = ItemsSource.IndexOf (SelectedItem);
-			var pagerIndicators = Children.Cast<StackLayout> ().ToList ();
+            CreateTabs();
+        }
 
-			foreach(var pi in pagerIndicators)
-			{
-				UnselectTab(pi);
-			}
+        void SelectedItemChanged()
+        {
 
-			if(selectedIndex > -1)
-			{
-				SelectTab(pagerIndicators[selectedIndex]);
-			}
-		}
+            var selectedIndex = ItemsSource.IndexOf(SelectedItem);
+            var pagerIndicators = Children.Cast<StackLayout>().ToList();
 
-		static void UnselectTab (StackLayout tab)
-		{
-			tab.Opacity = 0.5;
-		}
+            foreach (var pi in pagerIndicators)
+            {
+                UnselectTab(pi);
+            }
 
-		static void SelectTab (StackLayout tab)
-		{
-			tab.Opacity = 1.0;
-		}
-	}
+            if (selectedIndex > -1)
+            {
+                SelectTab(pagerIndicators[selectedIndex]);
+            }
+        }
+
+        static void UnselectTab(StackLayout tab)
+        {
+            tab.Opacity = 0.5;
+        }
+
+        static void SelectTab(StackLayout tab)
+        {
+            tab.Opacity = 1.0;
+        }
+    }
 }
 

--- a/src/Droid/CustomLayouts.Droid.csproj
+++ b/src/Droid/CustomLayouts.Droid.csproj
@@ -15,7 +15,7 @@
     <AndroidApplication>True</AndroidApplication>
     <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>
     <AssemblyName>CustomLayouts.Droid</AssemblyName>
-    <TargetFrameworkVersion>v6.0.99</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v7.1</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -67,19 +67,19 @@
       <HintPath>..\packages\Xamarin.Android.Support.v7.MediaRouter.23.3.0\lib\MonoAndroid403\Xamarin.Android.Support.v7.MediaRouter.dll</HintPath>
     </Reference>
     <Reference Include="FormsViewGroup">
-      <HintPath>..\packages\Xamarin.Forms.2.2.0.31\lib\MonoAndroid10\FormsViewGroup.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.2.3.4.231\lib\MonoAndroid10\FormsViewGroup.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Core">
-      <HintPath>..\packages\Xamarin.Forms.2.2.0.31\lib\MonoAndroid10\Xamarin.Forms.Core.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.2.3.4.231\lib\MonoAndroid10\Xamarin.Forms.Core.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Platform.Android">
-      <HintPath>..\packages\Xamarin.Forms.2.2.0.31\lib\MonoAndroid10\Xamarin.Forms.Platform.Android.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.2.3.4.231\lib\MonoAndroid10\Xamarin.Forms.Platform.Android.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Platform">
-      <HintPath>..\packages\Xamarin.Forms.2.2.0.31\lib\MonoAndroid10\Xamarin.Forms.Platform.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.2.3.4.231\lib\MonoAndroid10\Xamarin.Forms.Platform.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Xaml">
-      <HintPath>..\packages\Xamarin.Forms.2.2.0.31\lib\MonoAndroid10\Xamarin.Forms.Xaml.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.2.3.4.231\lib\MonoAndroid10\Xamarin.Forms.Xaml.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -109,5 +109,5 @@
   <Import Project="..\CustomLayouts\CustomLayouts.projitems" Label="Shared" Condition="Exists('..\CustomLayouts\CustomLayouts.projitems')" />
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
   <Import Project="..\packages\Xamarin.Android.Support.Vector.Drawable.23.3.0\build\Xamarin.Android.Support.Vector.Drawable.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Vector.Drawable.23.3.0\build\Xamarin.Android.Support.Vector.Drawable.targets')" />
-  <Import Project="..\packages\Xamarin.Forms.2.2.0.31\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets" Condition="Exists('..\packages\Xamarin.Forms.2.2.0.31\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets')" />
+  <Import Project="..\packages\Xamarin.Forms.2.3.4.231\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets" Condition="Exists('..\packages\Xamarin.Forms.2.3.4.231\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets')" />
 </Project>

--- a/src/Droid/Properties/AndroidManifest.xml
+++ b/src/Droid/Properties/AndroidManifest.xml
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.chrisriesgo.xamarin-forms-carouselview">
-	<uses-sdk android:minSdkVersion="15" android:targetSdkVersion="21" />
-	<application android:label="CarouselView Demo">
-	</application>
+	<uses-sdk android:minSdkVersion="15" />
+	<application android:label="CarouselView Demo"></application>
 </manifest>

--- a/src/Droid/Resources/Resource.designer.cs
+++ b/src/Droid/Resources/Resource.designer.cs
@@ -93,953 +93,953 @@ namespace CustomLayouts.Droid
 		public partial class Attribute
 		{
 			
-			// aapt resource value: 0x7f010000
-			public const int MediaRouteControllerWindowBackground = 2130771968;
-			
-			// aapt resource value: 0x7f010097
-			public const int actionBarDivider = 2130772119;
-			
-			// aapt resource value: 0x7f010098
-			public const int actionBarItemBackground = 2130772120;
-			
-			// aapt resource value: 0x7f010091
-			public const int actionBarPopupTheme = 2130772113;
-			
-			// aapt resource value: 0x7f010096
-			public const int actionBarSize = 2130772118;
-			
-			// aapt resource value: 0x7f010093
-			public const int actionBarSplitStyle = 2130772115;
-			
-			// aapt resource value: 0x7f010092
-			public const int actionBarStyle = 2130772114;
-			
-			// aapt resource value: 0x7f01008d
-			public const int actionBarTabBarStyle = 2130772109;
-			
-			// aapt resource value: 0x7f01008c
-			public const int actionBarTabStyle = 2130772108;
-			
-			// aapt resource value: 0x7f01008e
-			public const int actionBarTabTextStyle = 2130772110;
-			
-			// aapt resource value: 0x7f010094
-			public const int actionBarTheme = 2130772116;
-			
-			// aapt resource value: 0x7f010095
-			public const int actionBarWidgetTheme = 2130772117;
-			
-			// aapt resource value: 0x7f0100b1
-			public const int actionButtonStyle = 2130772145;
-			
-			// aapt resource value: 0x7f0100ad
-			public const int actionDropDownStyle = 2130772141;
-			
-			// aapt resource value: 0x7f0100ff
-			public const int actionLayout = 2130772223;
-			
-			// aapt resource value: 0x7f010099
-			public const int actionMenuTextAppearance = 2130772121;
-			
-			// aapt resource value: 0x7f01009a
-			public const int actionMenuTextColor = 2130772122;
-			
-			// aapt resource value: 0x7f01009d
-			public const int actionModeBackground = 2130772125;
-			
-			// aapt resource value: 0x7f01009c
-			public const int actionModeCloseButtonStyle = 2130772124;
-			
-			// aapt resource value: 0x7f01009f
-			public const int actionModeCloseDrawable = 2130772127;
-			
-			// aapt resource value: 0x7f0100a1
-			public const int actionModeCopyDrawable = 2130772129;
-			
-			// aapt resource value: 0x7f0100a0
-			public const int actionModeCutDrawable = 2130772128;
-			
-			// aapt resource value: 0x7f0100a5
-			public const int actionModeFindDrawable = 2130772133;
-			
-			// aapt resource value: 0x7f0100a2
-			public const int actionModePasteDrawable = 2130772130;
-			
-			// aapt resource value: 0x7f0100a7
-			public const int actionModePopupWindowStyle = 2130772135;
-			
-			// aapt resource value: 0x7f0100a3
-			public const int actionModeSelectAllDrawable = 2130772131;
-			
-			// aapt resource value: 0x7f0100a4
-			public const int actionModeShareDrawable = 2130772132;
-			
-			// aapt resource value: 0x7f01009e
-			public const int actionModeSplitBackground = 2130772126;
-			
-			// aapt resource value: 0x7f01009b
-			public const int actionModeStyle = 2130772123;
-			
-			// aapt resource value: 0x7f0100a6
-			public const int actionModeWebSearchDrawable = 2130772134;
-			
-			// aapt resource value: 0x7f01008f
-			public const int actionOverflowButtonStyle = 2130772111;
-			
-			// aapt resource value: 0x7f010090
-			public const int actionOverflowMenuStyle = 2130772112;
-			
-			// aapt resource value: 0x7f010101
-			public const int actionProviderClass = 2130772225;
-			
-			// aapt resource value: 0x7f010100
-			public const int actionViewClass = 2130772224;
-			
-			// aapt resource value: 0x7f0100b9
-			public const int activityChooserViewStyle = 2130772153;
-			
-			// aapt resource value: 0x7f0100dc
-			public const int alertDialogButtonGroupStyle = 2130772188;
-			
-			// aapt resource value: 0x7f0100dd
-			public const int alertDialogCenterButtons = 2130772189;
-			
-			// aapt resource value: 0x7f0100db
-			public const int alertDialogStyle = 2130772187;
-			
-			// aapt resource value: 0x7f0100de
-			public const int alertDialogTheme = 2130772190;
-			
-			// aapt resource value: 0x7f0100f0
-			public const int allowStacking = 2130772208;
-			
-			// aapt resource value: 0x7f0100f7
-			public const int arrowHeadLength = 2130772215;
-			
-			// aapt resource value: 0x7f0100f8
-			public const int arrowShaftLength = 2130772216;
-			
-			// aapt resource value: 0x7f0100e3
-			public const int autoCompleteTextViewStyle = 2130772195;
-			
-			// aapt resource value: 0x7f010068
-			public const int background = 2130772072;
-			
-			// aapt resource value: 0x7f01006a
-			public const int backgroundSplit = 2130772074;
-			
-			// aapt resource value: 0x7f010069
-			public const int backgroundStacked = 2130772073;
-			
-			// aapt resource value: 0x7f01012b
-			public const int backgroundTint = 2130772267;
-			
-			// aapt resource value: 0x7f01012c
-			public const int backgroundTintMode = 2130772268;
-			
-			// aapt resource value: 0x7f0100f9
-			public const int barLength = 2130772217;
-			
-			// aapt resource value: 0x7f01001b
-			public const int behavior_hideable = 2130771995;
-			
-			// aapt resource value: 0x7f010041
-			public const int behavior_overlapTop = 2130772033;
-			
-			// aapt resource value: 0x7f01001a
-			public const int behavior_peekHeight = 2130771994;
-			
-			// aapt resource value: 0x7f010037
-			public const int borderWidth = 2130772023;
-			
-			// aapt resource value: 0x7f0100b6
-			public const int borderlessButtonStyle = 2130772150;
-			
-			// aapt resource value: 0x7f010031
-			public const int bottomSheetDialogTheme = 2130772017;
-			
-			// aapt resource value: 0x7f010032
-			public const int bottomSheetStyle = 2130772018;
-			
-			// aapt resource value: 0x7f0100b3
-			public const int buttonBarButtonStyle = 2130772147;
-			
-			// aapt resource value: 0x7f0100e1
-			public const int buttonBarNegativeButtonStyle = 2130772193;
-			
-			// aapt resource value: 0x7f0100e2
-			public const int buttonBarNeutralButtonStyle = 2130772194;
-			
-			// aapt resource value: 0x7f0100e0
-			public const int buttonBarPositiveButtonStyle = 2130772192;
-			
-			// aapt resource value: 0x7f0100b2
-			public const int buttonBarStyle = 2130772146;
-			
-			// aapt resource value: 0x7f01007b
-			public const int buttonPanelSideLayout = 2130772091;
-			
-			// aapt resource value: 0x7f0100e4
-			public const int buttonStyle = 2130772196;
-			
-			// aapt resource value: 0x7f0100e5
-			public const int buttonStyleSmall = 2130772197;
-			
-			// aapt resource value: 0x7f0100f1
-			public const int buttonTint = 2130772209;
-			
-			// aapt resource value: 0x7f0100f2
-			public const int buttonTintMode = 2130772210;
-			
-			// aapt resource value: 0x7f010131
-			public const int cardBackgroundColor = 2130772273;
-			
-			// aapt resource value: 0x7f010132
-			public const int cardCornerRadius = 2130772274;
-			
-			// aapt resource value: 0x7f010133
-			public const int cardElevation = 2130772275;
-			
-			// aapt resource value: 0x7f010134
-			public const int cardMaxElevation = 2130772276;
-			
-			// aapt resource value: 0x7f010136
-			public const int cardPreventCornerOverlap = 2130772278;
-			
-			// aapt resource value: 0x7f010135
-			public const int cardUseCompatPadding = 2130772277;
-			
-			// aapt resource value: 0x7f0100e6
-			public const int checkboxStyle = 2130772198;
-			
-			// aapt resource value: 0x7f0100e7
-			public const int checkedTextViewStyle = 2130772199;
-			
-			// aapt resource value: 0x7f010109
-			public const int closeIcon = 2130772233;
-			
-			// aapt resource value: 0x7f010078
-			public const int closeItemLayout = 2130772088;
-			
-			// aapt resource value: 0x7f010122
-			public const int collapseContentDescription = 2130772258;
-			
-			// aapt resource value: 0x7f010121
-			public const int collapseIcon = 2130772257;
-			
-			// aapt resource value: 0x7f010028
-			public const int collapsedTitleGravity = 2130772008;
-			
-			// aapt resource value: 0x7f010024
-			public const int collapsedTitleTextAppearance = 2130772004;
-			
-			// aapt resource value: 0x7f0100f3
-			public const int color = 2130772211;
-			
-			// aapt resource value: 0x7f0100d4
-			public const int colorAccent = 2130772180;
-			
-			// aapt resource value: 0x7f0100d8
-			public const int colorButtonNormal = 2130772184;
-			
-			// aapt resource value: 0x7f0100d6
-			public const int colorControlActivated = 2130772182;
-			
-			// aapt resource value: 0x7f0100d7
-			public const int colorControlHighlight = 2130772183;
-			
-			// aapt resource value: 0x7f0100d5
-			public const int colorControlNormal = 2130772181;
-			
-			// aapt resource value: 0x7f0100d2
-			public const int colorPrimary = 2130772178;
-			
-			// aapt resource value: 0x7f0100d3
-			public const int colorPrimaryDark = 2130772179;
-			
-			// aapt resource value: 0x7f0100d9
-			public const int colorSwitchThumbNormal = 2130772185;
-			
-			// aapt resource value: 0x7f01010e
-			public const int commitIcon = 2130772238;
-			
-			// aapt resource value: 0x7f010073
-			public const int contentInsetEnd = 2130772083;
-			
-			// aapt resource value: 0x7f010074
-			public const int contentInsetLeft = 2130772084;
-			
-			// aapt resource value: 0x7f010075
-			public const int contentInsetRight = 2130772085;
-			
-			// aapt resource value: 0x7f010072
-			public const int contentInsetStart = 2130772082;
-			
-			// aapt resource value: 0x7f010137
-			public const int contentPadding = 2130772279;
-			
-			// aapt resource value: 0x7f01013b
-			public const int contentPaddingBottom = 2130772283;
-			
-			// aapt resource value: 0x7f010138
-			public const int contentPaddingLeft = 2130772280;
-			
-			// aapt resource value: 0x7f010139
-			public const int contentPaddingRight = 2130772281;
-			
-			// aapt resource value: 0x7f01013a
-			public const int contentPaddingTop = 2130772282;
-			
-			// aapt resource value: 0x7f010025
-			public const int contentScrim = 2130772005;
-			
-			// aapt resource value: 0x7f0100da
-			public const int controlBackground = 2130772186;
-			
-			// aapt resource value: 0x7f010057
-			public const int counterEnabled = 2130772055;
-			
-			// aapt resource value: 0x7f010058
-			public const int counterMaxLength = 2130772056;
-			
-			// aapt resource value: 0x7f01005a
-			public const int counterOverflowTextAppearance = 2130772058;
-			
-			// aapt resource value: 0x7f010059
-			public const int counterTextAppearance = 2130772057;
-			
-			// aapt resource value: 0x7f01006b
-			public const int customNavigationLayout = 2130772075;
-			
-			// aapt resource value: 0x7f010108
-			public const int defaultQueryHint = 2130772232;
-			
-			// aapt resource value: 0x7f0100ab
-			public const int dialogPreferredPadding = 2130772139;
-			
-			// aapt resource value: 0x7f0100aa
-			public const int dialogTheme = 2130772138;
+			// aapt resource value: 0x7f010004
+			public const int MediaRouteControllerWindowBackground = 2130771972;
 			
 			// aapt resource value: 0x7f010061
-			public const int displayOptions = 2130772065;
-			
-			// aapt resource value: 0x7f010067
-			public const int divider = 2130772071;
-			
-			// aapt resource value: 0x7f0100b8
-			public const int dividerHorizontal = 2130772152;
-			
-			// aapt resource value: 0x7f0100fd
-			public const int dividerPadding = 2130772221;
-			
-			// aapt resource value: 0x7f0100b7
-			public const int dividerVertical = 2130772151;
-			
-			// aapt resource value: 0x7f0100f5
-			public const int drawableSize = 2130772213;
-			
-			// aapt resource value: 0x7f01005c
-			public const int drawerArrowStyle = 2130772060;
-			
-			// aapt resource value: 0x7f0100ca
-			public const int dropDownListViewStyle = 2130772170;
-			
-			// aapt resource value: 0x7f0100ae
-			public const int dropdownListPreferredItemHeight = 2130772142;
-			
-			// aapt resource value: 0x7f0100bf
-			public const int editTextBackground = 2130772159;
-			
-			// aapt resource value: 0x7f0100be
-			public const int editTextColor = 2130772158;
-			
-			// aapt resource value: 0x7f0100e8
-			public const int editTextStyle = 2130772200;
-			
-			// aapt resource value: 0x7f010076
-			public const int elevation = 2130772086;
-			
-			// aapt resource value: 0x7f010055
-			public const int errorEnabled = 2130772053;
-			
-			// aapt resource value: 0x7f010056
-			public const int errorTextAppearance = 2130772054;
-			
-			// aapt resource value: 0x7f01007a
-			public const int expandActivityOverflowButtonDrawable = 2130772090;
-			
-			// aapt resource value: 0x7f010017
-			public const int expanded = 2130771991;
-			
-			// aapt resource value: 0x7f010029
-			public const int expandedTitleGravity = 2130772009;
-			
-			// aapt resource value: 0x7f01001e
-			public const int expandedTitleMargin = 2130771998;
-			
-			// aapt resource value: 0x7f010022
-			public const int expandedTitleMarginBottom = 2130772002;
-			
-			// aapt resource value: 0x7f010021
-			public const int expandedTitleMarginEnd = 2130772001;
-			
-			// aapt resource value: 0x7f01001f
-			public const int expandedTitleMarginStart = 2130771999;
-			
-			// aapt resource value: 0x7f010020
-			public const int expandedTitleMarginTop = 2130772000;
-			
-			// aapt resource value: 0x7f010023
-			public const int expandedTitleTextAppearance = 2130772003;
-			
-			// aapt resource value: 0x7f010016
-			public const int externalRouteEnabledDrawable = 2130771990;
-			
-			// aapt resource value: 0x7f010035
-			public const int fabSize = 2130772021;
-			
-			// aapt resource value: 0x7f010039
-			public const int foregroundInsidePadding = 2130772025;
-			
-			// aapt resource value: 0x7f0100f6
-			public const int gapBetweenBars = 2130772214;
-			
-			// aapt resource value: 0x7f01010a
-			public const int goIcon = 2130772234;
-			
-			// aapt resource value: 0x7f01003f
-			public const int headerLayout = 2130772031;
-			
-			// aapt resource value: 0x7f01005d
-			public const int height = 2130772061;
-			
-			// aapt resource value: 0x7f010071
-			public const int hideOnContentScroll = 2130772081;
-			
-			// aapt resource value: 0x7f01005b
-			public const int hintAnimationEnabled = 2130772059;
-			
-			// aapt resource value: 0x7f010054
-			public const int hintEnabled = 2130772052;
-			
-			// aapt resource value: 0x7f010053
-			public const int hintTextAppearance = 2130772051;
-			
-			// aapt resource value: 0x7f0100b0
-			public const int homeAsUpIndicator = 2130772144;
-			
-			// aapt resource value: 0x7f01006c
-			public const int homeLayout = 2130772076;
-			
-			// aapt resource value: 0x7f010065
-			public const int icon = 2130772069;
-			
-			// aapt resource value: 0x7f010106
-			public const int iconifiedByDefault = 2130772230;
-			
-			// aapt resource value: 0x7f0100c0
-			public const int imageButtonStyle = 2130772160;
-			
-			// aapt resource value: 0x7f01006e
-			public const int indeterminateProgressStyle = 2130772078;
-			
-			// aapt resource value: 0x7f010079
-			public const int initialActivityCount = 2130772089;
-			
-			// aapt resource value: 0x7f010040
-			public const int insetForeground = 2130772032;
-			
-			// aapt resource value: 0x7f01005e
-			public const int isLightTheme = 2130772062;
-			
-			// aapt resource value: 0x7f01003d
-			public const int itemBackground = 2130772029;
-			
-			// aapt resource value: 0x7f01003b
-			public const int itemIconTint = 2130772027;
-			
-			// aapt resource value: 0x7f010070
-			public const int itemPadding = 2130772080;
-			
-			// aapt resource value: 0x7f01003e
-			public const int itemTextAppearance = 2130772030;
-			
-			// aapt resource value: 0x7f01003c
-			public const int itemTextColor = 2130772028;
-			
-			// aapt resource value: 0x7f01002b
-			public const int keylines = 2130772011;
-			
-			// aapt resource value: 0x7f010105
-			public const int layout = 2130772229;
-			
-			// aapt resource value: 0x7f01012d
-			public const int layoutManager = 2130772269;
-			
-			// aapt resource value: 0x7f01002e
-			public const int layout_anchor = 2130772014;
-			
-			// aapt resource value: 0x7f010030
-			public const int layout_anchorGravity = 2130772016;
-			
-			// aapt resource value: 0x7f01002d
-			public const int layout_behavior = 2130772013;
-			
-			// aapt resource value: 0x7f01001c
-			public const int layout_collapseMode = 2130771996;
-			
-			// aapt resource value: 0x7f01001d
-			public const int layout_collapseParallaxMultiplier = 2130771997;
-			
-			// aapt resource value: 0x7f01002f
-			public const int layout_keyline = 2130772015;
-			
-			// aapt resource value: 0x7f010018
-			public const int layout_scrollFlags = 2130771992;
-			
-			// aapt resource value: 0x7f010019
-			public const int layout_scrollInterpolator = 2130771993;
-			
-			// aapt resource value: 0x7f0100d1
-			public const int listChoiceBackgroundIndicator = 2130772177;
-			
-			// aapt resource value: 0x7f0100ac
-			public const int listDividerAlertDialog = 2130772140;
-			
-			// aapt resource value: 0x7f01007f
-			public const int listItemLayout = 2130772095;
-			
-			// aapt resource value: 0x7f01007c
-			public const int listLayout = 2130772092;
-			
-			// aapt resource value: 0x7f0100cb
-			public const int listPopupWindowStyle = 2130772171;
-			
-			// aapt resource value: 0x7f0100c5
-			public const int listPreferredItemHeight = 2130772165;
-			
-			// aapt resource value: 0x7f0100c7
-			public const int listPreferredItemHeightLarge = 2130772167;
-			
-			// aapt resource value: 0x7f0100c6
-			public const int listPreferredItemHeightSmall = 2130772166;
-			
-			// aapt resource value: 0x7f0100c8
-			public const int listPreferredItemPaddingLeft = 2130772168;
-			
-			// aapt resource value: 0x7f0100c9
-			public const int listPreferredItemPaddingRight = 2130772169;
-			
-			// aapt resource value: 0x7f010066
-			public const int logo = 2130772070;
-			
-			// aapt resource value: 0x7f010125
-			public const int logoDescription = 2130772261;
-			
-			// aapt resource value: 0x7f010042
-			public const int maxActionInlineWidth = 2130772034;
-			
-			// aapt resource value: 0x7f010120
-			public const int maxButtonHeight = 2130772256;
-			
-			// aapt resource value: 0x7f0100fb
-			public const int measureWithLargestChild = 2130772219;
-			
-			// aapt resource value: 0x7f010001
-			public const int mediaRouteAudioTrackDrawable = 2130771969;
-			
-			// aapt resource value: 0x7f010002
-			public const int mediaRouteBluetoothIconDrawable = 2130771970;
-			
-			// aapt resource value: 0x7f010003
-			public const int mediaRouteButtonStyle = 2130771971;
-			
-			// aapt resource value: 0x7f010004
-			public const int mediaRouteCastDrawable = 2130771972;
-			
-			// aapt resource value: 0x7f010005
-			public const int mediaRouteChooserPrimaryTextStyle = 2130771973;
-			
-			// aapt resource value: 0x7f010006
-			public const int mediaRouteChooserSecondaryTextStyle = 2130771974;
-			
-			// aapt resource value: 0x7f010007
-			public const int mediaRouteCloseDrawable = 2130771975;
-			
-			// aapt resource value: 0x7f010008
-			public const int mediaRouteCollapseGroupDrawable = 2130771976;
-			
-			// aapt resource value: 0x7f010009
-			public const int mediaRouteConnectingDrawable = 2130771977;
-			
-			// aapt resource value: 0x7f01000a
-			public const int mediaRouteControllerPrimaryTextStyle = 2130771978;
-			
-			// aapt resource value: 0x7f01000b
-			public const int mediaRouteControllerSecondaryTextStyle = 2130771979;
-			
-			// aapt resource value: 0x7f01000c
-			public const int mediaRouteControllerTitleTextStyle = 2130771980;
-			
-			// aapt resource value: 0x7f01000d
-			public const int mediaRouteDefaultIconDrawable = 2130771981;
-			
-			// aapt resource value: 0x7f01000e
-			public const int mediaRouteExpandGroupDrawable = 2130771982;
-			
-			// aapt resource value: 0x7f01000f
-			public const int mediaRouteOffDrawable = 2130771983;
-			
-			// aapt resource value: 0x7f010010
-			public const int mediaRouteOnDrawable = 2130771984;
-			
-			// aapt resource value: 0x7f010011
-			public const int mediaRoutePauseDrawable = 2130771985;
-			
-			// aapt resource value: 0x7f010012
-			public const int mediaRoutePlayDrawable = 2130771986;
-			
-			// aapt resource value: 0x7f010013
-			public const int mediaRouteSpeakerGroupIconDrawable = 2130771987;
-			
-			// aapt resource value: 0x7f010014
-			public const int mediaRouteSpeakerIconDrawable = 2130771988;
-			
-			// aapt resource value: 0x7f010015
-			public const int mediaRouteTvIconDrawable = 2130771989;
-			
-			// aapt resource value: 0x7f01003a
-			public const int menu = 2130772026;
-			
-			// aapt resource value: 0x7f01007d
-			public const int multiChoiceItemLayout = 2130772093;
-			
-			// aapt resource value: 0x7f010124
-			public const int navigationContentDescription = 2130772260;
-			
-			// aapt resource value: 0x7f010123
-			public const int navigationIcon = 2130772259;
-			
-			// aapt resource value: 0x7f010060
-			public const int navigationMode = 2130772064;
-			
-			// aapt resource value: 0x7f010103
-			public const int overlapAnchor = 2130772227;
-			
-			// aapt resource value: 0x7f010129
-			public const int paddingEnd = 2130772265;
-			
-			// aapt resource value: 0x7f010128
-			public const int paddingStart = 2130772264;
-			
-			// aapt resource value: 0x7f0100ce
-			public const int panelBackground = 2130772174;
-			
-			// aapt resource value: 0x7f0100d0
-			public const int panelMenuListTheme = 2130772176;
-			
-			// aapt resource value: 0x7f0100cf
-			public const int panelMenuListWidth = 2130772175;
-			
-			// aapt resource value: 0x7f0100bc
-			public const int popupMenuStyle = 2130772156;
-			
-			// aapt resource value: 0x7f010077
-			public const int popupTheme = 2130772087;
-			
-			// aapt resource value: 0x7f0100bd
-			public const int popupWindowStyle = 2130772157;
-			
-			// aapt resource value: 0x7f010102
-			public const int preserveIconSpacing = 2130772226;
-			
-			// aapt resource value: 0x7f010036
-			public const int pressedTranslationZ = 2130772022;
-			
-			// aapt resource value: 0x7f01006f
-			public const int progressBarPadding = 2130772079;
-			
-			// aapt resource value: 0x7f01006d
-			public const int progressBarStyle = 2130772077;
-			
-			// aapt resource value: 0x7f010110
-			public const int queryBackground = 2130772240;
-			
-			// aapt resource value: 0x7f010107
-			public const int queryHint = 2130772231;
-			
-			// aapt resource value: 0x7f0100e9
-			public const int radioButtonStyle = 2130772201;
-			
-			// aapt resource value: 0x7f0100ea
-			public const int ratingBarStyle = 2130772202;
-			
-			// aapt resource value: 0x7f0100eb
-			public const int ratingBarStyleIndicator = 2130772203;
-			
-			// aapt resource value: 0x7f0100ec
-			public const int ratingBarStyleSmall = 2130772204;
-			
-			// aapt resource value: 0x7f01012f
-			public const int reverseLayout = 2130772271;
-			
-			// aapt resource value: 0x7f010034
-			public const int rippleColor = 2130772020;
-			
-			// aapt resource value: 0x7f01010c
-			public const int searchHintIcon = 2130772236;
-			
-			// aapt resource value: 0x7f01010b
-			public const int searchIcon = 2130772235;
-			
-			// aapt resource value: 0x7f0100c4
-			public const int searchViewStyle = 2130772164;
-			
-			// aapt resource value: 0x7f0100ed
-			public const int seekBarStyle = 2130772205;
-			
-			// aapt resource value: 0x7f0100b4
-			public const int selectableItemBackground = 2130772148;
-			
-			// aapt resource value: 0x7f0100b5
-			public const int selectableItemBackgroundBorderless = 2130772149;
-			
-			// aapt resource value: 0x7f0100fe
-			public const int showAsAction = 2130772222;
-			
-			// aapt resource value: 0x7f0100fc
-			public const int showDividers = 2130772220;
-			
-			// aapt resource value: 0x7f010118
-			public const int showText = 2130772248;
-			
-			// aapt resource value: 0x7f01007e
-			public const int singleChoiceItemLayout = 2130772094;
-			
-			// aapt resource value: 0x7f01012e
-			public const int spanCount = 2130772270;
-			
-			// aapt resource value: 0x7f0100f4
-			public const int spinBars = 2130772212;
-			
-			// aapt resource value: 0x7f0100af
-			public const int spinnerDropDownItemStyle = 2130772143;
-			
-			// aapt resource value: 0x7f0100ee
-			public const int spinnerStyle = 2130772206;
-			
-			// aapt resource value: 0x7f010117
-			public const int splitTrack = 2130772247;
-			
-			// aapt resource value: 0x7f010080
-			public const int srcCompat = 2130772096;
-			
-			// aapt resource value: 0x7f010130
-			public const int stackFromEnd = 2130772272;
-			
-			// aapt resource value: 0x7f010104
-			public const int state_above_anchor = 2130772228;
-			
-			// aapt resource value: 0x7f01002c
-			public const int statusBarBackground = 2130772012;
-			
-			// aapt resource value: 0x7f010026
-			public const int statusBarScrim = 2130772006;
-			
-			// aapt resource value: 0x7f010111
-			public const int submitBackground = 2130772241;
+			public const int actionBarDivider = 2130772065;
 			
 			// aapt resource value: 0x7f010062
-			public const int subtitle = 2130772066;
+			public const int actionBarItemBackground = 2130772066;
 			
-			// aapt resource value: 0x7f01011a
-			public const int subtitleTextAppearance = 2130772250;
+			// aapt resource value: 0x7f01005b
+			public const int actionBarPopupTheme = 2130772059;
 			
-			// aapt resource value: 0x7f010127
-			public const int subtitleTextColor = 2130772263;
+			// aapt resource value: 0x7f010060
+			public const int actionBarSize = 2130772064;
 			
-			// aapt resource value: 0x7f010064
-			public const int subtitleTextStyle = 2130772068;
+			// aapt resource value: 0x7f01005d
+			public const int actionBarSplitStyle = 2130772061;
 			
-			// aapt resource value: 0x7f01010f
-			public const int suggestionRowLayout = 2130772239;
+			// aapt resource value: 0x7f01005c
+			public const int actionBarStyle = 2130772060;
 			
-			// aapt resource value: 0x7f010115
-			public const int switchMinWidth = 2130772245;
+			// aapt resource value: 0x7f010057
+			public const int actionBarTabBarStyle = 2130772055;
 			
-			// aapt resource value: 0x7f010116
-			public const int switchPadding = 2130772246;
+			// aapt resource value: 0x7f010056
+			public const int actionBarTabStyle = 2130772054;
 			
-			// aapt resource value: 0x7f0100ef
-			public const int switchStyle = 2130772207;
+			// aapt resource value: 0x7f010058
+			public const int actionBarTabTextStyle = 2130772056;
 			
-			// aapt resource value: 0x7f010114
-			public const int switchTextAppearance = 2130772244;
-			
-			// aapt resource value: 0x7f010046
-			public const int tabBackground = 2130772038;
-			
-			// aapt resource value: 0x7f010045
-			public const int tabContentStart = 2130772037;
-			
-			// aapt resource value: 0x7f010048
-			public const int tabGravity = 2130772040;
-			
-			// aapt resource value: 0x7f010043
-			public const int tabIndicatorColor = 2130772035;
-			
-			// aapt resource value: 0x7f010044
-			public const int tabIndicatorHeight = 2130772036;
-			
-			// aapt resource value: 0x7f01004a
-			public const int tabMaxWidth = 2130772042;
-			
-			// aapt resource value: 0x7f010049
-			public const int tabMinWidth = 2130772041;
-			
-			// aapt resource value: 0x7f010047
-			public const int tabMode = 2130772039;
-			
-			// aapt resource value: 0x7f010052
-			public const int tabPadding = 2130772050;
-			
-			// aapt resource value: 0x7f010051
-			public const int tabPaddingBottom = 2130772049;
-			
-			// aapt resource value: 0x7f010050
-			public const int tabPaddingEnd = 2130772048;
-			
-			// aapt resource value: 0x7f01004e
-			public const int tabPaddingStart = 2130772046;
-			
-			// aapt resource value: 0x7f01004f
-			public const int tabPaddingTop = 2130772047;
-			
-			// aapt resource value: 0x7f01004d
-			public const int tabSelectedTextColor = 2130772045;
-			
-			// aapt resource value: 0x7f01004b
-			public const int tabTextAppearance = 2130772043;
-			
-			// aapt resource value: 0x7f01004c
-			public const int tabTextColor = 2130772044;
-			
-			// aapt resource value: 0x7f010081
-			public const int textAllCaps = 2130772097;
-			
-			// aapt resource value: 0x7f0100a8
-			public const int textAppearanceLargePopupMenu = 2130772136;
-			
-			// aapt resource value: 0x7f0100cc
-			public const int textAppearanceListItem = 2130772172;
-			
-			// aapt resource value: 0x7f0100cd
-			public const int textAppearanceListItemSmall = 2130772173;
-			
-			// aapt resource value: 0x7f0100c2
-			public const int textAppearanceSearchResultSubtitle = 2130772162;
-			
-			// aapt resource value: 0x7f0100c1
-			public const int textAppearanceSearchResultTitle = 2130772161;
-			
-			// aapt resource value: 0x7f0100a9
-			public const int textAppearanceSmallPopupMenu = 2130772137;
-			
-			// aapt resource value: 0x7f0100df
-			public const int textColorAlertDialogListItem = 2130772191;
-			
-			// aapt resource value: 0x7f010033
-			public const int textColorError = 2130772019;
-			
-			// aapt resource value: 0x7f0100c3
-			public const int textColorSearchUrl = 2130772163;
-			
-			// aapt resource value: 0x7f01012a
-			public const int theme = 2130772266;
-			
-			// aapt resource value: 0x7f0100fa
-			public const int thickness = 2130772218;
-			
-			// aapt resource value: 0x7f010113
-			public const int thumbTextPadding = 2130772243;
+			// aapt resource value: 0x7f01005e
+			public const int actionBarTheme = 2130772062;
 			
 			// aapt resource value: 0x7f01005f
-			public const int title = 2130772063;
+			public const int actionBarWidgetTheme = 2130772063;
 			
-			// aapt resource value: 0x7f01002a
-			public const int titleEnabled = 2130772010;
+			// aapt resource value: 0x7f01007b
+			public const int actionButtonStyle = 2130772091;
 			
-			// aapt resource value: 0x7f01011f
-			public const int titleMarginBottom = 2130772255;
+			// aapt resource value: 0x7f010077
+			public const int actionDropDownStyle = 2130772087;
 			
-			// aapt resource value: 0x7f01011d
-			public const int titleMarginEnd = 2130772253;
-			
-			// aapt resource value: 0x7f01011c
-			public const int titleMarginStart = 2130772252;
-			
-			// aapt resource value: 0x7f01011e
-			public const int titleMarginTop = 2130772254;
-			
-			// aapt resource value: 0x7f01011b
-			public const int titleMargins = 2130772251;
-			
-			// aapt resource value: 0x7f010119
-			public const int titleTextAppearance = 2130772249;
-			
-			// aapt resource value: 0x7f010126
-			public const int titleTextColor = 2130772262;
+			// aapt resource value: 0x7f0100c9
+			public const int actionLayout = 2130772169;
 			
 			// aapt resource value: 0x7f010063
-			public const int titleTextStyle = 2130772067;
+			public const int actionMenuTextAppearance = 2130772067;
 			
-			// aapt resource value: 0x7f010027
-			public const int toolbarId = 2130772007;
+			// aapt resource value: 0x7f010064
+			public const int actionMenuTextColor = 2130772068;
 			
-			// aapt resource value: 0x7f0100bb
-			public const int toolbarNavigationButtonStyle = 2130772155;
+			// aapt resource value: 0x7f010067
+			public const int actionModeBackground = 2130772071;
 			
-			// aapt resource value: 0x7f0100ba
-			public const int toolbarStyle = 2130772154;
+			// aapt resource value: 0x7f010066
+			public const int actionModeCloseButtonStyle = 2130772070;
 			
-			// aapt resource value: 0x7f010112
-			public const int track = 2130772242;
+			// aapt resource value: 0x7f010069
+			public const int actionModeCloseDrawable = 2130772073;
 			
-			// aapt resource value: 0x7f010038
-			public const int useCompatPadding = 2130772024;
+			// aapt resource value: 0x7f01006b
+			public const int actionModeCopyDrawable = 2130772075;
 			
-			// aapt resource value: 0x7f01010d
-			public const int voiceIcon = 2130772237;
+			// aapt resource value: 0x7f01006a
+			public const int actionModeCutDrawable = 2130772074;
 			
-			// aapt resource value: 0x7f010082
-			public const int windowActionBar = 2130772098;
+			// aapt resource value: 0x7f01006f
+			public const int actionModeFindDrawable = 2130772079;
 			
-			// aapt resource value: 0x7f010084
-			public const int windowActionBarOverlay = 2130772100;
+			// aapt resource value: 0x7f01006c
+			public const int actionModePasteDrawable = 2130772076;
 			
-			// aapt resource value: 0x7f010085
-			public const int windowActionModeOverlay = 2130772101;
+			// aapt resource value: 0x7f010071
+			public const int actionModePopupWindowStyle = 2130772081;
 			
-			// aapt resource value: 0x7f010089
-			public const int windowFixedHeightMajor = 2130772105;
+			// aapt resource value: 0x7f01006d
+			public const int actionModeSelectAllDrawable = 2130772077;
 			
-			// aapt resource value: 0x7f010087
-			public const int windowFixedHeightMinor = 2130772103;
+			// aapt resource value: 0x7f01006e
+			public const int actionModeShareDrawable = 2130772078;
 			
-			// aapt resource value: 0x7f010086
-			public const int windowFixedWidthMajor = 2130772102;
+			// aapt resource value: 0x7f010068
+			public const int actionModeSplitBackground = 2130772072;
 			
-			// aapt resource value: 0x7f010088
-			public const int windowFixedWidthMinor = 2130772104;
+			// aapt resource value: 0x7f010065
+			public const int actionModeStyle = 2130772069;
 			
-			// aapt resource value: 0x7f01008a
-			public const int windowMinWidthMajor = 2130772106;
+			// aapt resource value: 0x7f010070
+			public const int actionModeWebSearchDrawable = 2130772080;
 			
-			// aapt resource value: 0x7f01008b
-			public const int windowMinWidthMinor = 2130772107;
+			// aapt resource value: 0x7f010059
+			public const int actionOverflowButtonStyle = 2130772057;
+			
+			// aapt resource value: 0x7f01005a
+			public const int actionOverflowMenuStyle = 2130772058;
+			
+			// aapt resource value: 0x7f0100cb
+			public const int actionProviderClass = 2130772171;
+			
+			// aapt resource value: 0x7f0100ca
+			public const int actionViewClass = 2130772170;
 			
 			// aapt resource value: 0x7f010083
-			public const int windowNoTitle = 2130772099;
+			public const int activityChooserViewStyle = 2130772099;
+			
+			// aapt resource value: 0x7f0100a6
+			public const int alertDialogButtonGroupStyle = 2130772134;
+			
+			// aapt resource value: 0x7f0100a7
+			public const int alertDialogCenterButtons = 2130772135;
+			
+			// aapt resource value: 0x7f0100a5
+			public const int alertDialogStyle = 2130772133;
+			
+			// aapt resource value: 0x7f0100a8
+			public const int alertDialogTheme = 2130772136;
+			
+			// aapt resource value: 0x7f0100ba
+			public const int allowStacking = 2130772154;
+			
+			// aapt resource value: 0x7f0100c1
+			public const int arrowHeadLength = 2130772161;
+			
+			// aapt resource value: 0x7f0100c2
+			public const int arrowShaftLength = 2130772162;
+			
+			// aapt resource value: 0x7f0100ad
+			public const int autoCompleteTextViewStyle = 2130772141;
+			
+			// aapt resource value: 0x7f010032
+			public const int background = 2130772018;
+			
+			// aapt resource value: 0x7f010034
+			public const int backgroundSplit = 2130772020;
+			
+			// aapt resource value: 0x7f010033
+			public const int backgroundStacked = 2130772019;
+			
+			// aapt resource value: 0x7f0100f5
+			public const int backgroundTint = 2130772213;
+			
+			// aapt resource value: 0x7f0100f6
+			public const int backgroundTintMode = 2130772214;
+			
+			// aapt resource value: 0x7f0100c3
+			public const int barLength = 2130772163;
+			
+			// aapt resource value: 0x7f0100fb
+			public const int behavior_hideable = 2130772219;
+			
+			// aapt resource value: 0x7f010121
+			public const int behavior_overlapTop = 2130772257;
+			
+			// aapt resource value: 0x7f0100fa
+			public const int behavior_peekHeight = 2130772218;
+			
+			// aapt resource value: 0x7f010117
+			public const int borderWidth = 2130772247;
+			
+			// aapt resource value: 0x7f010080
+			public const int borderlessButtonStyle = 2130772096;
+			
+			// aapt resource value: 0x7f010111
+			public const int bottomSheetDialogTheme = 2130772241;
+			
+			// aapt resource value: 0x7f010112
+			public const int bottomSheetStyle = 2130772242;
+			
+			// aapt resource value: 0x7f01007d
+			public const int buttonBarButtonStyle = 2130772093;
+			
+			// aapt resource value: 0x7f0100ab
+			public const int buttonBarNegativeButtonStyle = 2130772139;
+			
+			// aapt resource value: 0x7f0100ac
+			public const int buttonBarNeutralButtonStyle = 2130772140;
+			
+			// aapt resource value: 0x7f0100aa
+			public const int buttonBarPositiveButtonStyle = 2130772138;
+			
+			// aapt resource value: 0x7f01007c
+			public const int buttonBarStyle = 2130772092;
+			
+			// aapt resource value: 0x7f010045
+			public const int buttonPanelSideLayout = 2130772037;
+			
+			// aapt resource value: 0x7f0100ae
+			public const int buttonStyle = 2130772142;
+			
+			// aapt resource value: 0x7f0100af
+			public const int buttonStyleSmall = 2130772143;
+			
+			// aapt resource value: 0x7f0100bb
+			public const int buttonTint = 2130772155;
+			
+			// aapt resource value: 0x7f0100bc
+			public const int buttonTintMode = 2130772156;
+			
+			// aapt resource value: 0x7f01001b
+			public const int cardBackgroundColor = 2130771995;
+			
+			// aapt resource value: 0x7f01001c
+			public const int cardCornerRadius = 2130771996;
+			
+			// aapt resource value: 0x7f01001d
+			public const int cardElevation = 2130771997;
+			
+			// aapt resource value: 0x7f01001e
+			public const int cardMaxElevation = 2130771998;
+			
+			// aapt resource value: 0x7f010020
+			public const int cardPreventCornerOverlap = 2130772000;
+			
+			// aapt resource value: 0x7f01001f
+			public const int cardUseCompatPadding = 2130771999;
+			
+			// aapt resource value: 0x7f0100b0
+			public const int checkboxStyle = 2130772144;
+			
+			// aapt resource value: 0x7f0100b1
+			public const int checkedTextViewStyle = 2130772145;
+			
+			// aapt resource value: 0x7f0100d3
+			public const int closeIcon = 2130772179;
+			
+			// aapt resource value: 0x7f010042
+			public const int closeItemLayout = 2130772034;
+			
+			// aapt resource value: 0x7f0100ec
+			public const int collapseContentDescription = 2130772204;
+			
+			// aapt resource value: 0x7f0100eb
+			public const int collapseIcon = 2130772203;
+			
+			// aapt resource value: 0x7f010108
+			public const int collapsedTitleGravity = 2130772232;
+			
+			// aapt resource value: 0x7f010104
+			public const int collapsedTitleTextAppearance = 2130772228;
+			
+			// aapt resource value: 0x7f0100bd
+			public const int color = 2130772157;
+			
+			// aapt resource value: 0x7f01009e
+			public const int colorAccent = 2130772126;
+			
+			// aapt resource value: 0x7f0100a2
+			public const int colorButtonNormal = 2130772130;
+			
+			// aapt resource value: 0x7f0100a0
+			public const int colorControlActivated = 2130772128;
+			
+			// aapt resource value: 0x7f0100a1
+			public const int colorControlHighlight = 2130772129;
+			
+			// aapt resource value: 0x7f01009f
+			public const int colorControlNormal = 2130772127;
+			
+			// aapt resource value: 0x7f01009c
+			public const int colorPrimary = 2130772124;
+			
+			// aapt resource value: 0x7f01009d
+			public const int colorPrimaryDark = 2130772125;
+			
+			// aapt resource value: 0x7f0100a3
+			public const int colorSwitchThumbNormal = 2130772131;
+			
+			// aapt resource value: 0x7f0100d8
+			public const int commitIcon = 2130772184;
+			
+			// aapt resource value: 0x7f01003d
+			public const int contentInsetEnd = 2130772029;
+			
+			// aapt resource value: 0x7f01003e
+			public const int contentInsetLeft = 2130772030;
+			
+			// aapt resource value: 0x7f01003f
+			public const int contentInsetRight = 2130772031;
+			
+			// aapt resource value: 0x7f01003c
+			public const int contentInsetStart = 2130772028;
+			
+			// aapt resource value: 0x7f010021
+			public const int contentPadding = 2130772001;
+			
+			// aapt resource value: 0x7f010025
+			public const int contentPaddingBottom = 2130772005;
+			
+			// aapt resource value: 0x7f010022
+			public const int contentPaddingLeft = 2130772002;
+			
+			// aapt resource value: 0x7f010023
+			public const int contentPaddingRight = 2130772003;
+			
+			// aapt resource value: 0x7f010024
+			public const int contentPaddingTop = 2130772004;
+			
+			// aapt resource value: 0x7f010105
+			public const int contentScrim = 2130772229;
+			
+			// aapt resource value: 0x7f0100a4
+			public const int controlBackground = 2130772132;
+			
+			// aapt resource value: 0x7f010137
+			public const int counterEnabled = 2130772279;
+			
+			// aapt resource value: 0x7f010138
+			public const int counterMaxLength = 2130772280;
+			
+			// aapt resource value: 0x7f01013a
+			public const int counterOverflowTextAppearance = 2130772282;
+			
+			// aapt resource value: 0x7f010139
+			public const int counterTextAppearance = 2130772281;
+			
+			// aapt resource value: 0x7f010035
+			public const int customNavigationLayout = 2130772021;
+			
+			// aapt resource value: 0x7f0100d2
+			public const int defaultQueryHint = 2130772178;
+			
+			// aapt resource value: 0x7f010075
+			public const int dialogPreferredPadding = 2130772085;
+			
+			// aapt resource value: 0x7f010074
+			public const int dialogTheme = 2130772084;
+			
+			// aapt resource value: 0x7f01002b
+			public const int displayOptions = 2130772011;
+			
+			// aapt resource value: 0x7f010031
+			public const int divider = 2130772017;
+			
+			// aapt resource value: 0x7f010082
+			public const int dividerHorizontal = 2130772098;
+			
+			// aapt resource value: 0x7f0100c7
+			public const int dividerPadding = 2130772167;
+			
+			// aapt resource value: 0x7f010081
+			public const int dividerVertical = 2130772097;
+			
+			// aapt resource value: 0x7f0100bf
+			public const int drawableSize = 2130772159;
+			
+			// aapt resource value: 0x7f010026
+			public const int drawerArrowStyle = 2130772006;
+			
+			// aapt resource value: 0x7f010094
+			public const int dropDownListViewStyle = 2130772116;
+			
+			// aapt resource value: 0x7f010078
+			public const int dropdownListPreferredItemHeight = 2130772088;
+			
+			// aapt resource value: 0x7f010089
+			public const int editTextBackground = 2130772105;
+			
+			// aapt resource value: 0x7f010088
+			public const int editTextColor = 2130772104;
+			
+			// aapt resource value: 0x7f0100b2
+			public const int editTextStyle = 2130772146;
+			
+			// aapt resource value: 0x7f010040
+			public const int elevation = 2130772032;
+			
+			// aapt resource value: 0x7f010135
+			public const int errorEnabled = 2130772277;
+			
+			// aapt resource value: 0x7f010136
+			public const int errorTextAppearance = 2130772278;
+			
+			// aapt resource value: 0x7f010044
+			public const int expandActivityOverflowButtonDrawable = 2130772036;
+			
+			// aapt resource value: 0x7f0100f7
+			public const int expanded = 2130772215;
+			
+			// aapt resource value: 0x7f010109
+			public const int expandedTitleGravity = 2130772233;
+			
+			// aapt resource value: 0x7f0100fe
+			public const int expandedTitleMargin = 2130772222;
+			
+			// aapt resource value: 0x7f010102
+			public const int expandedTitleMarginBottom = 2130772226;
+			
+			// aapt resource value: 0x7f010101
+			public const int expandedTitleMarginEnd = 2130772225;
+			
+			// aapt resource value: 0x7f0100ff
+			public const int expandedTitleMarginStart = 2130772223;
+			
+			// aapt resource value: 0x7f010100
+			public const int expandedTitleMarginTop = 2130772224;
+			
+			// aapt resource value: 0x7f010103
+			public const int expandedTitleTextAppearance = 2130772227;
+			
+			// aapt resource value: 0x7f01001a
+			public const int externalRouteEnabledDrawable = 2130771994;
+			
+			// aapt resource value: 0x7f010115
+			public const int fabSize = 2130772245;
+			
+			// aapt resource value: 0x7f010119
+			public const int foregroundInsidePadding = 2130772249;
+			
+			// aapt resource value: 0x7f0100c0
+			public const int gapBetweenBars = 2130772160;
+			
+			// aapt resource value: 0x7f0100d4
+			public const int goIcon = 2130772180;
+			
+			// aapt resource value: 0x7f01011f
+			public const int headerLayout = 2130772255;
+			
+			// aapt resource value: 0x7f010027
+			public const int height = 2130772007;
+			
+			// aapt resource value: 0x7f01003b
+			public const int hideOnContentScroll = 2130772027;
+			
+			// aapt resource value: 0x7f01013b
+			public const int hintAnimationEnabled = 2130772283;
+			
+			// aapt resource value: 0x7f010134
+			public const int hintEnabled = 2130772276;
+			
+			// aapt resource value: 0x7f010133
+			public const int hintTextAppearance = 2130772275;
+			
+			// aapt resource value: 0x7f01007a
+			public const int homeAsUpIndicator = 2130772090;
+			
+			// aapt resource value: 0x7f010036
+			public const int homeLayout = 2130772022;
+			
+			// aapt resource value: 0x7f01002f
+			public const int icon = 2130772015;
+			
+			// aapt resource value: 0x7f0100d0
+			public const int iconifiedByDefault = 2130772176;
+			
+			// aapt resource value: 0x7f01008a
+			public const int imageButtonStyle = 2130772106;
+			
+			// aapt resource value: 0x7f010038
+			public const int indeterminateProgressStyle = 2130772024;
+			
+			// aapt resource value: 0x7f010043
+			public const int initialActivityCount = 2130772035;
+			
+			// aapt resource value: 0x7f010120
+			public const int insetForeground = 2130772256;
+			
+			// aapt resource value: 0x7f010028
+			public const int isLightTheme = 2130772008;
+			
+			// aapt resource value: 0x7f01011d
+			public const int itemBackground = 2130772253;
+			
+			// aapt resource value: 0x7f01011b
+			public const int itemIconTint = 2130772251;
+			
+			// aapt resource value: 0x7f01003a
+			public const int itemPadding = 2130772026;
+			
+			// aapt resource value: 0x7f01011e
+			public const int itemTextAppearance = 2130772254;
+			
+			// aapt resource value: 0x7f01011c
+			public const int itemTextColor = 2130772252;
+			
+			// aapt resource value: 0x7f01010b
+			public const int keylines = 2130772235;
+			
+			// aapt resource value: 0x7f0100cf
+			public const int layout = 2130772175;
+			
+			// aapt resource value: 0x7f010000
+			public const int layoutManager = 2130771968;
+			
+			// aapt resource value: 0x7f01010e
+			public const int layout_anchor = 2130772238;
+			
+			// aapt resource value: 0x7f010110
+			public const int layout_anchorGravity = 2130772240;
+			
+			// aapt resource value: 0x7f01010d
+			public const int layout_behavior = 2130772237;
+			
+			// aapt resource value: 0x7f0100fc
+			public const int layout_collapseMode = 2130772220;
+			
+			// aapt resource value: 0x7f0100fd
+			public const int layout_collapseParallaxMultiplier = 2130772221;
+			
+			// aapt resource value: 0x7f01010f
+			public const int layout_keyline = 2130772239;
+			
+			// aapt resource value: 0x7f0100f8
+			public const int layout_scrollFlags = 2130772216;
+			
+			// aapt resource value: 0x7f0100f9
+			public const int layout_scrollInterpolator = 2130772217;
+			
+			// aapt resource value: 0x7f01009b
+			public const int listChoiceBackgroundIndicator = 2130772123;
+			
+			// aapt resource value: 0x7f010076
+			public const int listDividerAlertDialog = 2130772086;
+			
+			// aapt resource value: 0x7f010049
+			public const int listItemLayout = 2130772041;
+			
+			// aapt resource value: 0x7f010046
+			public const int listLayout = 2130772038;
+			
+			// aapt resource value: 0x7f010095
+			public const int listPopupWindowStyle = 2130772117;
+			
+			// aapt resource value: 0x7f01008f
+			public const int listPreferredItemHeight = 2130772111;
+			
+			// aapt resource value: 0x7f010091
+			public const int listPreferredItemHeightLarge = 2130772113;
+			
+			// aapt resource value: 0x7f010090
+			public const int listPreferredItemHeightSmall = 2130772112;
+			
+			// aapt resource value: 0x7f010092
+			public const int listPreferredItemPaddingLeft = 2130772114;
+			
+			// aapt resource value: 0x7f010093
+			public const int listPreferredItemPaddingRight = 2130772115;
+			
+			// aapt resource value: 0x7f010030
+			public const int logo = 2130772016;
+			
+			// aapt resource value: 0x7f0100ef
+			public const int logoDescription = 2130772207;
+			
+			// aapt resource value: 0x7f010122
+			public const int maxActionInlineWidth = 2130772258;
+			
+			// aapt resource value: 0x7f0100ea
+			public const int maxButtonHeight = 2130772202;
+			
+			// aapt resource value: 0x7f0100c5
+			public const int measureWithLargestChild = 2130772165;
+			
+			// aapt resource value: 0x7f010005
+			public const int mediaRouteAudioTrackDrawable = 2130771973;
+			
+			// aapt resource value: 0x7f010006
+			public const int mediaRouteBluetoothIconDrawable = 2130771974;
+			
+			// aapt resource value: 0x7f010007
+			public const int mediaRouteButtonStyle = 2130771975;
+			
+			// aapt resource value: 0x7f010008
+			public const int mediaRouteCastDrawable = 2130771976;
+			
+			// aapt resource value: 0x7f010009
+			public const int mediaRouteChooserPrimaryTextStyle = 2130771977;
+			
+			// aapt resource value: 0x7f01000a
+			public const int mediaRouteChooserSecondaryTextStyle = 2130771978;
+			
+			// aapt resource value: 0x7f01000b
+			public const int mediaRouteCloseDrawable = 2130771979;
+			
+			// aapt resource value: 0x7f01000c
+			public const int mediaRouteCollapseGroupDrawable = 2130771980;
+			
+			// aapt resource value: 0x7f01000d
+			public const int mediaRouteConnectingDrawable = 2130771981;
+			
+			// aapt resource value: 0x7f01000e
+			public const int mediaRouteControllerPrimaryTextStyle = 2130771982;
+			
+			// aapt resource value: 0x7f01000f
+			public const int mediaRouteControllerSecondaryTextStyle = 2130771983;
+			
+			// aapt resource value: 0x7f010010
+			public const int mediaRouteControllerTitleTextStyle = 2130771984;
+			
+			// aapt resource value: 0x7f010011
+			public const int mediaRouteDefaultIconDrawable = 2130771985;
+			
+			// aapt resource value: 0x7f010012
+			public const int mediaRouteExpandGroupDrawable = 2130771986;
+			
+			// aapt resource value: 0x7f010013
+			public const int mediaRouteOffDrawable = 2130771987;
+			
+			// aapt resource value: 0x7f010014
+			public const int mediaRouteOnDrawable = 2130771988;
+			
+			// aapt resource value: 0x7f010015
+			public const int mediaRoutePauseDrawable = 2130771989;
+			
+			// aapt resource value: 0x7f010016
+			public const int mediaRoutePlayDrawable = 2130771990;
+			
+			// aapt resource value: 0x7f010017
+			public const int mediaRouteSpeakerGroupIconDrawable = 2130771991;
+			
+			// aapt resource value: 0x7f010018
+			public const int mediaRouteSpeakerIconDrawable = 2130771992;
+			
+			// aapt resource value: 0x7f010019
+			public const int mediaRouteTvIconDrawable = 2130771993;
+			
+			// aapt resource value: 0x7f01011a
+			public const int menu = 2130772250;
+			
+			// aapt resource value: 0x7f010047
+			public const int multiChoiceItemLayout = 2130772039;
+			
+			// aapt resource value: 0x7f0100ee
+			public const int navigationContentDescription = 2130772206;
+			
+			// aapt resource value: 0x7f0100ed
+			public const int navigationIcon = 2130772205;
+			
+			// aapt resource value: 0x7f01002a
+			public const int navigationMode = 2130772010;
+			
+			// aapt resource value: 0x7f0100cd
+			public const int overlapAnchor = 2130772173;
+			
+			// aapt resource value: 0x7f0100f3
+			public const int paddingEnd = 2130772211;
+			
+			// aapt resource value: 0x7f0100f2
+			public const int paddingStart = 2130772210;
+			
+			// aapt resource value: 0x7f010098
+			public const int panelBackground = 2130772120;
+			
+			// aapt resource value: 0x7f01009a
+			public const int panelMenuListTheme = 2130772122;
+			
+			// aapt resource value: 0x7f010099
+			public const int panelMenuListWidth = 2130772121;
+			
+			// aapt resource value: 0x7f010086
+			public const int popupMenuStyle = 2130772102;
+			
+			// aapt resource value: 0x7f010041
+			public const int popupTheme = 2130772033;
+			
+			// aapt resource value: 0x7f010087
+			public const int popupWindowStyle = 2130772103;
+			
+			// aapt resource value: 0x7f0100cc
+			public const int preserveIconSpacing = 2130772172;
+			
+			// aapt resource value: 0x7f010116
+			public const int pressedTranslationZ = 2130772246;
+			
+			// aapt resource value: 0x7f010039
+			public const int progressBarPadding = 2130772025;
+			
+			// aapt resource value: 0x7f010037
+			public const int progressBarStyle = 2130772023;
+			
+			// aapt resource value: 0x7f0100da
+			public const int queryBackground = 2130772186;
+			
+			// aapt resource value: 0x7f0100d1
+			public const int queryHint = 2130772177;
+			
+			// aapt resource value: 0x7f0100b3
+			public const int radioButtonStyle = 2130772147;
+			
+			// aapt resource value: 0x7f0100b4
+			public const int ratingBarStyle = 2130772148;
+			
+			// aapt resource value: 0x7f0100b5
+			public const int ratingBarStyleIndicator = 2130772149;
+			
+			// aapt resource value: 0x7f0100b6
+			public const int ratingBarStyleSmall = 2130772150;
+			
+			// aapt resource value: 0x7f010002
+			public const int reverseLayout = 2130771970;
+			
+			// aapt resource value: 0x7f010114
+			public const int rippleColor = 2130772244;
+			
+			// aapt resource value: 0x7f0100d6
+			public const int searchHintIcon = 2130772182;
+			
+			// aapt resource value: 0x7f0100d5
+			public const int searchIcon = 2130772181;
+			
+			// aapt resource value: 0x7f01008e
+			public const int searchViewStyle = 2130772110;
+			
+			// aapt resource value: 0x7f0100b7
+			public const int seekBarStyle = 2130772151;
+			
+			// aapt resource value: 0x7f01007e
+			public const int selectableItemBackground = 2130772094;
+			
+			// aapt resource value: 0x7f01007f
+			public const int selectableItemBackgroundBorderless = 2130772095;
+			
+			// aapt resource value: 0x7f0100c8
+			public const int showAsAction = 2130772168;
+			
+			// aapt resource value: 0x7f0100c6
+			public const int showDividers = 2130772166;
+			
+			// aapt resource value: 0x7f0100e2
+			public const int showText = 2130772194;
+			
+			// aapt resource value: 0x7f010048
+			public const int singleChoiceItemLayout = 2130772040;
+			
+			// aapt resource value: 0x7f010001
+			public const int spanCount = 2130771969;
+			
+			// aapt resource value: 0x7f0100be
+			public const int spinBars = 2130772158;
+			
+			// aapt resource value: 0x7f010079
+			public const int spinnerDropDownItemStyle = 2130772089;
+			
+			// aapt resource value: 0x7f0100b8
+			public const int spinnerStyle = 2130772152;
+			
+			// aapt resource value: 0x7f0100e1
+			public const int splitTrack = 2130772193;
+			
+			// aapt resource value: 0x7f01004a
+			public const int srcCompat = 2130772042;
+			
+			// aapt resource value: 0x7f010003
+			public const int stackFromEnd = 2130771971;
+			
+			// aapt resource value: 0x7f0100ce
+			public const int state_above_anchor = 2130772174;
+			
+			// aapt resource value: 0x7f01010c
+			public const int statusBarBackground = 2130772236;
+			
+			// aapt resource value: 0x7f010106
+			public const int statusBarScrim = 2130772230;
+			
+			// aapt resource value: 0x7f0100db
+			public const int submitBackground = 2130772187;
+			
+			// aapt resource value: 0x7f01002c
+			public const int subtitle = 2130772012;
+			
+			// aapt resource value: 0x7f0100e4
+			public const int subtitleTextAppearance = 2130772196;
+			
+			// aapt resource value: 0x7f0100f1
+			public const int subtitleTextColor = 2130772209;
+			
+			// aapt resource value: 0x7f01002e
+			public const int subtitleTextStyle = 2130772014;
+			
+			// aapt resource value: 0x7f0100d9
+			public const int suggestionRowLayout = 2130772185;
+			
+			// aapt resource value: 0x7f0100df
+			public const int switchMinWidth = 2130772191;
+			
+			// aapt resource value: 0x7f0100e0
+			public const int switchPadding = 2130772192;
+			
+			// aapt resource value: 0x7f0100b9
+			public const int switchStyle = 2130772153;
+			
+			// aapt resource value: 0x7f0100de
+			public const int switchTextAppearance = 2130772190;
+			
+			// aapt resource value: 0x7f010126
+			public const int tabBackground = 2130772262;
+			
+			// aapt resource value: 0x7f010125
+			public const int tabContentStart = 2130772261;
+			
+			// aapt resource value: 0x7f010128
+			public const int tabGravity = 2130772264;
+			
+			// aapt resource value: 0x7f010123
+			public const int tabIndicatorColor = 2130772259;
+			
+			// aapt resource value: 0x7f010124
+			public const int tabIndicatorHeight = 2130772260;
+			
+			// aapt resource value: 0x7f01012a
+			public const int tabMaxWidth = 2130772266;
+			
+			// aapt resource value: 0x7f010129
+			public const int tabMinWidth = 2130772265;
+			
+			// aapt resource value: 0x7f010127
+			public const int tabMode = 2130772263;
+			
+			// aapt resource value: 0x7f010132
+			public const int tabPadding = 2130772274;
+			
+			// aapt resource value: 0x7f010131
+			public const int tabPaddingBottom = 2130772273;
+			
+			// aapt resource value: 0x7f010130
+			public const int tabPaddingEnd = 2130772272;
+			
+			// aapt resource value: 0x7f01012e
+			public const int tabPaddingStart = 2130772270;
+			
+			// aapt resource value: 0x7f01012f
+			public const int tabPaddingTop = 2130772271;
+			
+			// aapt resource value: 0x7f01012d
+			public const int tabSelectedTextColor = 2130772269;
+			
+			// aapt resource value: 0x7f01012b
+			public const int tabTextAppearance = 2130772267;
+			
+			// aapt resource value: 0x7f01012c
+			public const int tabTextColor = 2130772268;
+			
+			// aapt resource value: 0x7f01004b
+			public const int textAllCaps = 2130772043;
+			
+			// aapt resource value: 0x7f010072
+			public const int textAppearanceLargePopupMenu = 2130772082;
+			
+			// aapt resource value: 0x7f010096
+			public const int textAppearanceListItem = 2130772118;
+			
+			// aapt resource value: 0x7f010097
+			public const int textAppearanceListItemSmall = 2130772119;
+			
+			// aapt resource value: 0x7f01008c
+			public const int textAppearanceSearchResultSubtitle = 2130772108;
+			
+			// aapt resource value: 0x7f01008b
+			public const int textAppearanceSearchResultTitle = 2130772107;
+			
+			// aapt resource value: 0x7f010073
+			public const int textAppearanceSmallPopupMenu = 2130772083;
+			
+			// aapt resource value: 0x7f0100a9
+			public const int textColorAlertDialogListItem = 2130772137;
+			
+			// aapt resource value: 0x7f010113
+			public const int textColorError = 2130772243;
+			
+			// aapt resource value: 0x7f01008d
+			public const int textColorSearchUrl = 2130772109;
+			
+			// aapt resource value: 0x7f0100f4
+			public const int theme = 2130772212;
+			
+			// aapt resource value: 0x7f0100c4
+			public const int thickness = 2130772164;
+			
+			// aapt resource value: 0x7f0100dd
+			public const int thumbTextPadding = 2130772189;
+			
+			// aapt resource value: 0x7f010029
+			public const int title = 2130772009;
+			
+			// aapt resource value: 0x7f01010a
+			public const int titleEnabled = 2130772234;
+			
+			// aapt resource value: 0x7f0100e9
+			public const int titleMarginBottom = 2130772201;
+			
+			// aapt resource value: 0x7f0100e7
+			public const int titleMarginEnd = 2130772199;
+			
+			// aapt resource value: 0x7f0100e6
+			public const int titleMarginStart = 2130772198;
+			
+			// aapt resource value: 0x7f0100e8
+			public const int titleMarginTop = 2130772200;
+			
+			// aapt resource value: 0x7f0100e5
+			public const int titleMargins = 2130772197;
+			
+			// aapt resource value: 0x7f0100e3
+			public const int titleTextAppearance = 2130772195;
+			
+			// aapt resource value: 0x7f0100f0
+			public const int titleTextColor = 2130772208;
+			
+			// aapt resource value: 0x7f01002d
+			public const int titleTextStyle = 2130772013;
+			
+			// aapt resource value: 0x7f010107
+			public const int toolbarId = 2130772231;
+			
+			// aapt resource value: 0x7f010085
+			public const int toolbarNavigationButtonStyle = 2130772101;
+			
+			// aapt resource value: 0x7f010084
+			public const int toolbarStyle = 2130772100;
+			
+			// aapt resource value: 0x7f0100dc
+			public const int track = 2130772188;
+			
+			// aapt resource value: 0x7f010118
+			public const int useCompatPadding = 2130772248;
+			
+			// aapt resource value: 0x7f0100d7
+			public const int voiceIcon = 2130772183;
+			
+			// aapt resource value: 0x7f01004c
+			public const int windowActionBar = 2130772044;
+			
+			// aapt resource value: 0x7f01004e
+			public const int windowActionBarOverlay = 2130772046;
+			
+			// aapt resource value: 0x7f01004f
+			public const int windowActionModeOverlay = 2130772047;
+			
+			// aapt resource value: 0x7f010053
+			public const int windowFixedHeightMajor = 2130772051;
+			
+			// aapt resource value: 0x7f010051
+			public const int windowFixedHeightMinor = 2130772049;
+			
+			// aapt resource value: 0x7f010050
+			public const int windowFixedWidthMajor = 2130772048;
+			
+			// aapt resource value: 0x7f010052
+			public const int windowFixedWidthMinor = 2130772050;
+			
+			// aapt resource value: 0x7f010054
+			public const int windowMinWidthMajor = 2130772052;
+			
+			// aapt resource value: 0x7f010055
+			public const int windowMinWidthMinor = 2130772053;
+			
+			// aapt resource value: 0x7f01004d
+			public const int windowNoTitle = 2130772045;
 			
 			static Attribute()
 			{
@@ -1091,257 +1091,257 @@ namespace CustomLayouts.Droid
 		public partial class Color
 		{
 			
-			// aapt resource value: 0x7f0a0048
-			public const int abc_background_cache_hint_selector_material_dark = 2131361864;
+			// aapt resource value: 0x7f0b0048
+			public const int abc_background_cache_hint_selector_material_dark = 2131427400;
 			
-			// aapt resource value: 0x7f0a0049
-			public const int abc_background_cache_hint_selector_material_light = 2131361865;
+			// aapt resource value: 0x7f0b0049
+			public const int abc_background_cache_hint_selector_material_light = 2131427401;
 			
-			// aapt resource value: 0x7f0a004a
-			public const int abc_color_highlight_material = 2131361866;
+			// aapt resource value: 0x7f0b004a
+			public const int abc_color_highlight_material = 2131427402;
 			
-			// aapt resource value: 0x7f0a000a
-			public const int abc_input_method_navigation_guard = 2131361802;
+			// aapt resource value: 0x7f0b0004
+			public const int abc_input_method_navigation_guard = 2131427332;
 			
-			// aapt resource value: 0x7f0a004b
-			public const int abc_primary_text_disable_only_material_dark = 2131361867;
+			// aapt resource value: 0x7f0b004b
+			public const int abc_primary_text_disable_only_material_dark = 2131427403;
 			
-			// aapt resource value: 0x7f0a004c
-			public const int abc_primary_text_disable_only_material_light = 2131361868;
+			// aapt resource value: 0x7f0b004c
+			public const int abc_primary_text_disable_only_material_light = 2131427404;
 			
-			// aapt resource value: 0x7f0a004d
-			public const int abc_primary_text_material_dark = 2131361869;
+			// aapt resource value: 0x7f0b004d
+			public const int abc_primary_text_material_dark = 2131427405;
 			
-			// aapt resource value: 0x7f0a004e
-			public const int abc_primary_text_material_light = 2131361870;
+			// aapt resource value: 0x7f0b004e
+			public const int abc_primary_text_material_light = 2131427406;
 			
-			// aapt resource value: 0x7f0a004f
-			public const int abc_search_url_text = 2131361871;
+			// aapt resource value: 0x7f0b004f
+			public const int abc_search_url_text = 2131427407;
 			
-			// aapt resource value: 0x7f0a000b
-			public const int abc_search_url_text_normal = 2131361803;
+			// aapt resource value: 0x7f0b0005
+			public const int abc_search_url_text_normal = 2131427333;
 			
-			// aapt resource value: 0x7f0a000c
-			public const int abc_search_url_text_pressed = 2131361804;
+			// aapt resource value: 0x7f0b0006
+			public const int abc_search_url_text_pressed = 2131427334;
 			
-			// aapt resource value: 0x7f0a000d
-			public const int abc_search_url_text_selected = 2131361805;
+			// aapt resource value: 0x7f0b0007
+			public const int abc_search_url_text_selected = 2131427335;
 			
-			// aapt resource value: 0x7f0a0050
-			public const int abc_secondary_text_material_dark = 2131361872;
+			// aapt resource value: 0x7f0b0050
+			public const int abc_secondary_text_material_dark = 2131427408;
 			
-			// aapt resource value: 0x7f0a0051
-			public const int abc_secondary_text_material_light = 2131361873;
+			// aapt resource value: 0x7f0b0051
+			public const int abc_secondary_text_material_light = 2131427409;
 			
-			// aapt resource value: 0x7f0a000e
-			public const int accent_material_dark = 2131361806;
+			// aapt resource value: 0x7f0b0008
+			public const int accent_material_dark = 2131427336;
 			
-			// aapt resource value: 0x7f0a000f
-			public const int accent_material_light = 2131361807;
+			// aapt resource value: 0x7f0b0009
+			public const int accent_material_light = 2131427337;
 			
-			// aapt resource value: 0x7f0a0010
-			public const int background_floating_material_dark = 2131361808;
+			// aapt resource value: 0x7f0b000a
+			public const int background_floating_material_dark = 2131427338;
 			
-			// aapt resource value: 0x7f0a0011
-			public const int background_floating_material_light = 2131361809;
+			// aapt resource value: 0x7f0b000b
+			public const int background_floating_material_light = 2131427339;
 			
-			// aapt resource value: 0x7f0a0012
-			public const int background_material_dark = 2131361810;
+			// aapt resource value: 0x7f0b000c
+			public const int background_material_dark = 2131427340;
 			
-			// aapt resource value: 0x7f0a0013
-			public const int background_material_light = 2131361811;
+			// aapt resource value: 0x7f0b000d
+			public const int background_material_light = 2131427341;
 			
-			// aapt resource value: 0x7f0a0014
-			public const int bright_foreground_disabled_material_dark = 2131361812;
+			// aapt resource value: 0x7f0b000e
+			public const int bright_foreground_disabled_material_dark = 2131427342;
 			
-			// aapt resource value: 0x7f0a0015
-			public const int bright_foreground_disabled_material_light = 2131361813;
+			// aapt resource value: 0x7f0b000f
+			public const int bright_foreground_disabled_material_light = 2131427343;
 			
-			// aapt resource value: 0x7f0a0016
-			public const int bright_foreground_inverse_material_dark = 2131361814;
+			// aapt resource value: 0x7f0b0010
+			public const int bright_foreground_inverse_material_dark = 2131427344;
 			
-			// aapt resource value: 0x7f0a0017
-			public const int bright_foreground_inverse_material_light = 2131361815;
+			// aapt resource value: 0x7f0b0011
+			public const int bright_foreground_inverse_material_light = 2131427345;
 			
-			// aapt resource value: 0x7f0a0018
-			public const int bright_foreground_material_dark = 2131361816;
+			// aapt resource value: 0x7f0b0012
+			public const int bright_foreground_material_dark = 2131427346;
 			
-			// aapt resource value: 0x7f0a0019
-			public const int bright_foreground_material_light = 2131361817;
+			// aapt resource value: 0x7f0b0013
+			public const int bright_foreground_material_light = 2131427347;
 			
-			// aapt resource value: 0x7f0a001a
-			public const int button_material_dark = 2131361818;
+			// aapt resource value: 0x7f0b0014
+			public const int button_material_dark = 2131427348;
 			
-			// aapt resource value: 0x7f0a001b
-			public const int button_material_light = 2131361819;
+			// aapt resource value: 0x7f0b0015
+			public const int button_material_light = 2131427349;
 			
-			// aapt resource value: 0x7f0a0044
-			public const int cardview_dark_background = 2131361860;
+			// aapt resource value: 0x7f0b0000
+			public const int cardview_dark_background = 2131427328;
 			
-			// aapt resource value: 0x7f0a0045
-			public const int cardview_light_background = 2131361861;
+			// aapt resource value: 0x7f0b0001
+			public const int cardview_light_background = 2131427329;
 			
-			// aapt resource value: 0x7f0a0046
-			public const int cardview_shadow_end_color = 2131361862;
+			// aapt resource value: 0x7f0b0002
+			public const int cardview_shadow_end_color = 2131427330;
 			
-			// aapt resource value: 0x7f0a0047
-			public const int cardview_shadow_start_color = 2131361863;
+			// aapt resource value: 0x7f0b0003
+			public const int cardview_shadow_start_color = 2131427331;
 			
-			// aapt resource value: 0x7f0a0000
-			public const int design_fab_shadow_end_color = 2131361792;
+			// aapt resource value: 0x7f0b003e
+			public const int design_fab_shadow_end_color = 2131427390;
 			
-			// aapt resource value: 0x7f0a0001
-			public const int design_fab_shadow_mid_color = 2131361793;
+			// aapt resource value: 0x7f0b003f
+			public const int design_fab_shadow_mid_color = 2131427391;
 			
-			// aapt resource value: 0x7f0a0002
-			public const int design_fab_shadow_start_color = 2131361794;
+			// aapt resource value: 0x7f0b0040
+			public const int design_fab_shadow_start_color = 2131427392;
 			
-			// aapt resource value: 0x7f0a0003
-			public const int design_fab_stroke_end_inner_color = 2131361795;
+			// aapt resource value: 0x7f0b0041
+			public const int design_fab_stroke_end_inner_color = 2131427393;
 			
-			// aapt resource value: 0x7f0a0004
-			public const int design_fab_stroke_end_outer_color = 2131361796;
+			// aapt resource value: 0x7f0b0042
+			public const int design_fab_stroke_end_outer_color = 2131427394;
 			
-			// aapt resource value: 0x7f0a0005
-			public const int design_fab_stroke_top_inner_color = 2131361797;
+			// aapt resource value: 0x7f0b0043
+			public const int design_fab_stroke_top_inner_color = 2131427395;
 			
-			// aapt resource value: 0x7f0a0006
-			public const int design_fab_stroke_top_outer_color = 2131361798;
+			// aapt resource value: 0x7f0b0044
+			public const int design_fab_stroke_top_outer_color = 2131427396;
 			
-			// aapt resource value: 0x7f0a0007
-			public const int design_snackbar_background_color = 2131361799;
+			// aapt resource value: 0x7f0b0045
+			public const int design_snackbar_background_color = 2131427397;
 			
-			// aapt resource value: 0x7f0a0008
-			public const int design_textinput_error_color_dark = 2131361800;
+			// aapt resource value: 0x7f0b0046
+			public const int design_textinput_error_color_dark = 2131427398;
 			
-			// aapt resource value: 0x7f0a0009
-			public const int design_textinput_error_color_light = 2131361801;
+			// aapt resource value: 0x7f0b0047
+			public const int design_textinput_error_color_light = 2131427399;
 			
-			// aapt resource value: 0x7f0a001c
-			public const int dim_foreground_disabled_material_dark = 2131361820;
+			// aapt resource value: 0x7f0b0016
+			public const int dim_foreground_disabled_material_dark = 2131427350;
 			
-			// aapt resource value: 0x7f0a001d
-			public const int dim_foreground_disabled_material_light = 2131361821;
+			// aapt resource value: 0x7f0b0017
+			public const int dim_foreground_disabled_material_light = 2131427351;
 			
-			// aapt resource value: 0x7f0a001e
-			public const int dim_foreground_material_dark = 2131361822;
+			// aapt resource value: 0x7f0b0018
+			public const int dim_foreground_material_dark = 2131427352;
 			
-			// aapt resource value: 0x7f0a001f
-			public const int dim_foreground_material_light = 2131361823;
+			// aapt resource value: 0x7f0b0019
+			public const int dim_foreground_material_light = 2131427353;
 			
-			// aapt resource value: 0x7f0a0020
-			public const int foreground_material_dark = 2131361824;
+			// aapt resource value: 0x7f0b001a
+			public const int foreground_material_dark = 2131427354;
 			
-			// aapt resource value: 0x7f0a0021
-			public const int foreground_material_light = 2131361825;
+			// aapt resource value: 0x7f0b001b
+			public const int foreground_material_light = 2131427355;
 			
-			// aapt resource value: 0x7f0a0022
-			public const int highlighted_text_material_dark = 2131361826;
+			// aapt resource value: 0x7f0b001c
+			public const int highlighted_text_material_dark = 2131427356;
 			
-			// aapt resource value: 0x7f0a0023
-			public const int highlighted_text_material_light = 2131361827;
+			// aapt resource value: 0x7f0b001d
+			public const int highlighted_text_material_light = 2131427357;
 			
-			// aapt resource value: 0x7f0a0024
-			public const int hint_foreground_material_dark = 2131361828;
+			// aapt resource value: 0x7f0b001e
+			public const int hint_foreground_material_dark = 2131427358;
 			
-			// aapt resource value: 0x7f0a0025
-			public const int hint_foreground_material_light = 2131361829;
+			// aapt resource value: 0x7f0b001f
+			public const int hint_foreground_material_light = 2131427359;
 			
-			// aapt resource value: 0x7f0a0026
-			public const int material_blue_grey_800 = 2131361830;
+			// aapt resource value: 0x7f0b0020
+			public const int material_blue_grey_800 = 2131427360;
 			
-			// aapt resource value: 0x7f0a0027
-			public const int material_blue_grey_900 = 2131361831;
+			// aapt resource value: 0x7f0b0021
+			public const int material_blue_grey_900 = 2131427361;
 			
-			// aapt resource value: 0x7f0a0028
-			public const int material_blue_grey_950 = 2131361832;
+			// aapt resource value: 0x7f0b0022
+			public const int material_blue_grey_950 = 2131427362;
 			
-			// aapt resource value: 0x7f0a0029
-			public const int material_deep_teal_200 = 2131361833;
+			// aapt resource value: 0x7f0b0023
+			public const int material_deep_teal_200 = 2131427363;
 			
-			// aapt resource value: 0x7f0a002a
-			public const int material_deep_teal_500 = 2131361834;
+			// aapt resource value: 0x7f0b0024
+			public const int material_deep_teal_500 = 2131427364;
 			
-			// aapt resource value: 0x7f0a002b
-			public const int material_grey_100 = 2131361835;
+			// aapt resource value: 0x7f0b0025
+			public const int material_grey_100 = 2131427365;
 			
-			// aapt resource value: 0x7f0a002c
-			public const int material_grey_300 = 2131361836;
+			// aapt resource value: 0x7f0b0026
+			public const int material_grey_300 = 2131427366;
 			
-			// aapt resource value: 0x7f0a002d
-			public const int material_grey_50 = 2131361837;
+			// aapt resource value: 0x7f0b0027
+			public const int material_grey_50 = 2131427367;
 			
-			// aapt resource value: 0x7f0a002e
-			public const int material_grey_600 = 2131361838;
+			// aapt resource value: 0x7f0b0028
+			public const int material_grey_600 = 2131427368;
 			
-			// aapt resource value: 0x7f0a002f
-			public const int material_grey_800 = 2131361839;
+			// aapt resource value: 0x7f0b0029
+			public const int material_grey_800 = 2131427369;
 			
-			// aapt resource value: 0x7f0a0030
-			public const int material_grey_850 = 2131361840;
+			// aapt resource value: 0x7f0b002a
+			public const int material_grey_850 = 2131427370;
 			
-			// aapt resource value: 0x7f0a0031
-			public const int material_grey_900 = 2131361841;
+			// aapt resource value: 0x7f0b002b
+			public const int material_grey_900 = 2131427371;
 			
-			// aapt resource value: 0x7f0a0032
-			public const int primary_dark_material_dark = 2131361842;
+			// aapt resource value: 0x7f0b002c
+			public const int primary_dark_material_dark = 2131427372;
 			
-			// aapt resource value: 0x7f0a0033
-			public const int primary_dark_material_light = 2131361843;
+			// aapt resource value: 0x7f0b002d
+			public const int primary_dark_material_light = 2131427373;
 			
-			// aapt resource value: 0x7f0a0034
-			public const int primary_material_dark = 2131361844;
+			// aapt resource value: 0x7f0b002e
+			public const int primary_material_dark = 2131427374;
 			
-			// aapt resource value: 0x7f0a0035
-			public const int primary_material_light = 2131361845;
+			// aapt resource value: 0x7f0b002f
+			public const int primary_material_light = 2131427375;
 			
-			// aapt resource value: 0x7f0a0036
-			public const int primary_text_default_material_dark = 2131361846;
+			// aapt resource value: 0x7f0b0030
+			public const int primary_text_default_material_dark = 2131427376;
 			
-			// aapt resource value: 0x7f0a0037
-			public const int primary_text_default_material_light = 2131361847;
+			// aapt resource value: 0x7f0b0031
+			public const int primary_text_default_material_light = 2131427377;
 			
-			// aapt resource value: 0x7f0a0038
-			public const int primary_text_disabled_material_dark = 2131361848;
+			// aapt resource value: 0x7f0b0032
+			public const int primary_text_disabled_material_dark = 2131427378;
 			
-			// aapt resource value: 0x7f0a0039
-			public const int primary_text_disabled_material_light = 2131361849;
+			// aapt resource value: 0x7f0b0033
+			public const int primary_text_disabled_material_light = 2131427379;
 			
-			// aapt resource value: 0x7f0a003a
-			public const int ripple_material_dark = 2131361850;
+			// aapt resource value: 0x7f0b0034
+			public const int ripple_material_dark = 2131427380;
 			
-			// aapt resource value: 0x7f0a003b
-			public const int ripple_material_light = 2131361851;
+			// aapt resource value: 0x7f0b0035
+			public const int ripple_material_light = 2131427381;
 			
-			// aapt resource value: 0x7f0a003c
-			public const int secondary_text_default_material_dark = 2131361852;
+			// aapt resource value: 0x7f0b0036
+			public const int secondary_text_default_material_dark = 2131427382;
 			
-			// aapt resource value: 0x7f0a003d
-			public const int secondary_text_default_material_light = 2131361853;
+			// aapt resource value: 0x7f0b0037
+			public const int secondary_text_default_material_light = 2131427383;
 			
-			// aapt resource value: 0x7f0a003e
-			public const int secondary_text_disabled_material_dark = 2131361854;
+			// aapt resource value: 0x7f0b0038
+			public const int secondary_text_disabled_material_dark = 2131427384;
 			
-			// aapt resource value: 0x7f0a003f
-			public const int secondary_text_disabled_material_light = 2131361855;
+			// aapt resource value: 0x7f0b0039
+			public const int secondary_text_disabled_material_light = 2131427385;
 			
-			// aapt resource value: 0x7f0a0040
-			public const int switch_thumb_disabled_material_dark = 2131361856;
+			// aapt resource value: 0x7f0b003a
+			public const int switch_thumb_disabled_material_dark = 2131427386;
 			
-			// aapt resource value: 0x7f0a0041
-			public const int switch_thumb_disabled_material_light = 2131361857;
+			// aapt resource value: 0x7f0b003b
+			public const int switch_thumb_disabled_material_light = 2131427387;
 			
-			// aapt resource value: 0x7f0a0052
-			public const int switch_thumb_material_dark = 2131361874;
+			// aapt resource value: 0x7f0b0052
+			public const int switch_thumb_material_dark = 2131427410;
 			
-			// aapt resource value: 0x7f0a0053
-			public const int switch_thumb_material_light = 2131361875;
+			// aapt resource value: 0x7f0b0053
+			public const int switch_thumb_material_light = 2131427411;
 			
-			// aapt resource value: 0x7f0a0042
-			public const int switch_thumb_normal_material_dark = 2131361858;
+			// aapt resource value: 0x7f0b003c
+			public const int switch_thumb_normal_material_dark = 2131427388;
 			
-			// aapt resource value: 0x7f0a0043
-			public const int switch_thumb_normal_material_light = 2131361859;
+			// aapt resource value: 0x7f0b003d
+			public const int switch_thumb_normal_material_light = 2131427389;
 			
 			static Color()
 			{
@@ -1356,353 +1356,353 @@ namespace CustomLayouts.Droid
 		public partial class Dimension
 		{
 			
-			// aapt resource value: 0x7f070030
-			public const int abc_action_bar_content_inset_material = 2131165232;
+			// aapt resource value: 0x7f060019
+			public const int abc_action_bar_content_inset_material = 2131099673;
 			
-			// aapt resource value: 0x7f070024
-			public const int abc_action_bar_default_height_material = 2131165220;
+			// aapt resource value: 0x7f06000d
+			public const int abc_action_bar_default_height_material = 2131099661;
 			
-			// aapt resource value: 0x7f070031
-			public const int abc_action_bar_default_padding_end_material = 2131165233;
+			// aapt resource value: 0x7f06001a
+			public const int abc_action_bar_default_padding_end_material = 2131099674;
 			
-			// aapt resource value: 0x7f070032
-			public const int abc_action_bar_default_padding_start_material = 2131165234;
+			// aapt resource value: 0x7f06001b
+			public const int abc_action_bar_default_padding_start_material = 2131099675;
 			
-			// aapt resource value: 0x7f070034
-			public const int abc_action_bar_icon_vertical_padding_material = 2131165236;
+			// aapt resource value: 0x7f06001d
+			public const int abc_action_bar_icon_vertical_padding_material = 2131099677;
 			
-			// aapt resource value: 0x7f070035
-			public const int abc_action_bar_overflow_padding_end_material = 2131165237;
+			// aapt resource value: 0x7f06001e
+			public const int abc_action_bar_overflow_padding_end_material = 2131099678;
 			
-			// aapt resource value: 0x7f070036
-			public const int abc_action_bar_overflow_padding_start_material = 2131165238;
+			// aapt resource value: 0x7f06001f
+			public const int abc_action_bar_overflow_padding_start_material = 2131099679;
 			
-			// aapt resource value: 0x7f070025
-			public const int abc_action_bar_progress_bar_size = 2131165221;
+			// aapt resource value: 0x7f06000e
+			public const int abc_action_bar_progress_bar_size = 2131099662;
 			
-			// aapt resource value: 0x7f070037
-			public const int abc_action_bar_stacked_max_height = 2131165239;
+			// aapt resource value: 0x7f060020
+			public const int abc_action_bar_stacked_max_height = 2131099680;
 			
-			// aapt resource value: 0x7f070038
-			public const int abc_action_bar_stacked_tab_max_width = 2131165240;
+			// aapt resource value: 0x7f060021
+			public const int abc_action_bar_stacked_tab_max_width = 2131099681;
 			
-			// aapt resource value: 0x7f070039
-			public const int abc_action_bar_subtitle_bottom_margin_material = 2131165241;
+			// aapt resource value: 0x7f060022
+			public const int abc_action_bar_subtitle_bottom_margin_material = 2131099682;
 			
-			// aapt resource value: 0x7f07003a
-			public const int abc_action_bar_subtitle_top_margin_material = 2131165242;
+			// aapt resource value: 0x7f060023
+			public const int abc_action_bar_subtitle_top_margin_material = 2131099683;
 			
-			// aapt resource value: 0x7f07003b
-			public const int abc_action_button_min_height_material = 2131165243;
+			// aapt resource value: 0x7f060024
+			public const int abc_action_button_min_height_material = 2131099684;
 			
-			// aapt resource value: 0x7f07003c
-			public const int abc_action_button_min_width_material = 2131165244;
+			// aapt resource value: 0x7f060025
+			public const int abc_action_button_min_width_material = 2131099685;
 			
-			// aapt resource value: 0x7f07003d
-			public const int abc_action_button_min_width_overflow_material = 2131165245;
+			// aapt resource value: 0x7f060026
+			public const int abc_action_button_min_width_overflow_material = 2131099686;
 			
-			// aapt resource value: 0x7f070023
-			public const int abc_alert_dialog_button_bar_height = 2131165219;
+			// aapt resource value: 0x7f06000c
+			public const int abc_alert_dialog_button_bar_height = 2131099660;
 			
-			// aapt resource value: 0x7f07003e
-			public const int abc_button_inset_horizontal_material = 2131165246;
+			// aapt resource value: 0x7f060027
+			public const int abc_button_inset_horizontal_material = 2131099687;
 			
-			// aapt resource value: 0x7f07003f
-			public const int abc_button_inset_vertical_material = 2131165247;
+			// aapt resource value: 0x7f060028
+			public const int abc_button_inset_vertical_material = 2131099688;
 			
-			// aapt resource value: 0x7f070040
-			public const int abc_button_padding_horizontal_material = 2131165248;
+			// aapt resource value: 0x7f060029
+			public const int abc_button_padding_horizontal_material = 2131099689;
 			
-			// aapt resource value: 0x7f070041
-			public const int abc_button_padding_vertical_material = 2131165249;
+			// aapt resource value: 0x7f06002a
+			public const int abc_button_padding_vertical_material = 2131099690;
 			
-			// aapt resource value: 0x7f070028
-			public const int abc_config_prefDialogWidth = 2131165224;
+			// aapt resource value: 0x7f060011
+			public const int abc_config_prefDialogWidth = 2131099665;
 			
-			// aapt resource value: 0x7f070042
-			public const int abc_control_corner_material = 2131165250;
+			// aapt resource value: 0x7f06002b
+			public const int abc_control_corner_material = 2131099691;
 			
-			// aapt resource value: 0x7f070043
-			public const int abc_control_inset_material = 2131165251;
+			// aapt resource value: 0x7f06002c
+			public const int abc_control_inset_material = 2131099692;
 			
-			// aapt resource value: 0x7f070044
-			public const int abc_control_padding_material = 2131165252;
+			// aapt resource value: 0x7f06002d
+			public const int abc_control_padding_material = 2131099693;
 			
-			// aapt resource value: 0x7f070029
-			public const int abc_dialog_fixed_height_major = 2131165225;
+			// aapt resource value: 0x7f060012
+			public const int abc_dialog_fixed_height_major = 2131099666;
 			
-			// aapt resource value: 0x7f07002a
-			public const int abc_dialog_fixed_height_minor = 2131165226;
+			// aapt resource value: 0x7f060013
+			public const int abc_dialog_fixed_height_minor = 2131099667;
 			
-			// aapt resource value: 0x7f07002b
-			public const int abc_dialog_fixed_width_major = 2131165227;
+			// aapt resource value: 0x7f060014
+			public const int abc_dialog_fixed_width_major = 2131099668;
 			
-			// aapt resource value: 0x7f07002c
-			public const int abc_dialog_fixed_width_minor = 2131165228;
+			// aapt resource value: 0x7f060015
+			public const int abc_dialog_fixed_width_minor = 2131099669;
 			
-			// aapt resource value: 0x7f070045
-			public const int abc_dialog_list_padding_vertical_material = 2131165253;
+			// aapt resource value: 0x7f06002e
+			public const int abc_dialog_list_padding_vertical_material = 2131099694;
 			
-			// aapt resource value: 0x7f07002d
-			public const int abc_dialog_min_width_major = 2131165229;
+			// aapt resource value: 0x7f060016
+			public const int abc_dialog_min_width_major = 2131099670;
 			
-			// aapt resource value: 0x7f07002e
-			public const int abc_dialog_min_width_minor = 2131165230;
+			// aapt resource value: 0x7f060017
+			public const int abc_dialog_min_width_minor = 2131099671;
 			
-			// aapt resource value: 0x7f070046
-			public const int abc_dialog_padding_material = 2131165254;
+			// aapt resource value: 0x7f06002f
+			public const int abc_dialog_padding_material = 2131099695;
 			
-			// aapt resource value: 0x7f070047
-			public const int abc_dialog_padding_top_material = 2131165255;
+			// aapt resource value: 0x7f060030
+			public const int abc_dialog_padding_top_material = 2131099696;
 			
-			// aapt resource value: 0x7f070048
-			public const int abc_disabled_alpha_material_dark = 2131165256;
+			// aapt resource value: 0x7f060031
+			public const int abc_disabled_alpha_material_dark = 2131099697;
 			
-			// aapt resource value: 0x7f070049
-			public const int abc_disabled_alpha_material_light = 2131165257;
+			// aapt resource value: 0x7f060032
+			public const int abc_disabled_alpha_material_light = 2131099698;
 			
-			// aapt resource value: 0x7f07004a
-			public const int abc_dropdownitem_icon_width = 2131165258;
+			// aapt resource value: 0x7f060033
+			public const int abc_dropdownitem_icon_width = 2131099699;
 			
-			// aapt resource value: 0x7f07004b
-			public const int abc_dropdownitem_text_padding_left = 2131165259;
+			// aapt resource value: 0x7f060034
+			public const int abc_dropdownitem_text_padding_left = 2131099700;
 			
-			// aapt resource value: 0x7f07004c
-			public const int abc_dropdownitem_text_padding_right = 2131165260;
+			// aapt resource value: 0x7f060035
+			public const int abc_dropdownitem_text_padding_right = 2131099701;
 			
-			// aapt resource value: 0x7f07004d
-			public const int abc_edit_text_inset_bottom_material = 2131165261;
+			// aapt resource value: 0x7f060036
+			public const int abc_edit_text_inset_bottom_material = 2131099702;
 			
-			// aapt resource value: 0x7f07004e
-			public const int abc_edit_text_inset_horizontal_material = 2131165262;
+			// aapt resource value: 0x7f060037
+			public const int abc_edit_text_inset_horizontal_material = 2131099703;
 			
-			// aapt resource value: 0x7f07004f
-			public const int abc_edit_text_inset_top_material = 2131165263;
+			// aapt resource value: 0x7f060038
+			public const int abc_edit_text_inset_top_material = 2131099704;
 			
-			// aapt resource value: 0x7f070050
-			public const int abc_floating_window_z = 2131165264;
+			// aapt resource value: 0x7f060039
+			public const int abc_floating_window_z = 2131099705;
 			
-			// aapt resource value: 0x7f070051
-			public const int abc_list_item_padding_horizontal_material = 2131165265;
+			// aapt resource value: 0x7f06003a
+			public const int abc_list_item_padding_horizontal_material = 2131099706;
 			
-			// aapt resource value: 0x7f070052
-			public const int abc_panel_menu_list_width = 2131165266;
+			// aapt resource value: 0x7f06003b
+			public const int abc_panel_menu_list_width = 2131099707;
 			
-			// aapt resource value: 0x7f070053
-			public const int abc_search_view_preferred_width = 2131165267;
+			// aapt resource value: 0x7f06003c
+			public const int abc_search_view_preferred_width = 2131099708;
 			
-			// aapt resource value: 0x7f07002f
-			public const int abc_search_view_text_min_width = 2131165231;
+			// aapt resource value: 0x7f060018
+			public const int abc_search_view_text_min_width = 2131099672;
 			
-			// aapt resource value: 0x7f070054
-			public const int abc_seekbar_track_background_height_material = 2131165268;
+			// aapt resource value: 0x7f06003d
+			public const int abc_seekbar_track_background_height_material = 2131099709;
 			
-			// aapt resource value: 0x7f070055
-			public const int abc_seekbar_track_progress_height_material = 2131165269;
+			// aapt resource value: 0x7f06003e
+			public const int abc_seekbar_track_progress_height_material = 2131099710;
 			
-			// aapt resource value: 0x7f070056
-			public const int abc_select_dialog_padding_start_material = 2131165270;
+			// aapt resource value: 0x7f06003f
+			public const int abc_select_dialog_padding_start_material = 2131099711;
 			
-			// aapt resource value: 0x7f070033
-			public const int abc_switch_padding = 2131165235;
+			// aapt resource value: 0x7f06001c
+			public const int abc_switch_padding = 2131099676;
 			
-			// aapt resource value: 0x7f070057
-			public const int abc_text_size_body_1_material = 2131165271;
+			// aapt resource value: 0x7f060040
+			public const int abc_text_size_body_1_material = 2131099712;
 			
-			// aapt resource value: 0x7f070058
-			public const int abc_text_size_body_2_material = 2131165272;
+			// aapt resource value: 0x7f060041
+			public const int abc_text_size_body_2_material = 2131099713;
 			
-			// aapt resource value: 0x7f070059
-			public const int abc_text_size_button_material = 2131165273;
+			// aapt resource value: 0x7f060042
+			public const int abc_text_size_button_material = 2131099714;
 			
-			// aapt resource value: 0x7f07005a
-			public const int abc_text_size_caption_material = 2131165274;
+			// aapt resource value: 0x7f060043
+			public const int abc_text_size_caption_material = 2131099715;
 			
-			// aapt resource value: 0x7f07005b
-			public const int abc_text_size_display_1_material = 2131165275;
+			// aapt resource value: 0x7f060044
+			public const int abc_text_size_display_1_material = 2131099716;
 			
-			// aapt resource value: 0x7f07005c
-			public const int abc_text_size_display_2_material = 2131165276;
+			// aapt resource value: 0x7f060045
+			public const int abc_text_size_display_2_material = 2131099717;
 			
-			// aapt resource value: 0x7f07005d
-			public const int abc_text_size_display_3_material = 2131165277;
+			// aapt resource value: 0x7f060046
+			public const int abc_text_size_display_3_material = 2131099718;
 			
-			// aapt resource value: 0x7f07005e
-			public const int abc_text_size_display_4_material = 2131165278;
+			// aapt resource value: 0x7f060047
+			public const int abc_text_size_display_4_material = 2131099719;
 			
-			// aapt resource value: 0x7f07005f
-			public const int abc_text_size_headline_material = 2131165279;
+			// aapt resource value: 0x7f060048
+			public const int abc_text_size_headline_material = 2131099720;
 			
-			// aapt resource value: 0x7f070060
-			public const int abc_text_size_large_material = 2131165280;
+			// aapt resource value: 0x7f060049
+			public const int abc_text_size_large_material = 2131099721;
 			
-			// aapt resource value: 0x7f070061
-			public const int abc_text_size_medium_material = 2131165281;
+			// aapt resource value: 0x7f06004a
+			public const int abc_text_size_medium_material = 2131099722;
 			
-			// aapt resource value: 0x7f070062
-			public const int abc_text_size_menu_material = 2131165282;
+			// aapt resource value: 0x7f06004b
+			public const int abc_text_size_menu_material = 2131099723;
 			
-			// aapt resource value: 0x7f070063
-			public const int abc_text_size_small_material = 2131165283;
+			// aapt resource value: 0x7f06004c
+			public const int abc_text_size_small_material = 2131099724;
 			
-			// aapt resource value: 0x7f070064
-			public const int abc_text_size_subhead_material = 2131165284;
+			// aapt resource value: 0x7f06004d
+			public const int abc_text_size_subhead_material = 2131099725;
 			
-			// aapt resource value: 0x7f070026
-			public const int abc_text_size_subtitle_material_toolbar = 2131165222;
+			// aapt resource value: 0x7f06000f
+			public const int abc_text_size_subtitle_material_toolbar = 2131099663;
 			
-			// aapt resource value: 0x7f070065
-			public const int abc_text_size_title_material = 2131165285;
+			// aapt resource value: 0x7f06004e
+			public const int abc_text_size_title_material = 2131099726;
 			
-			// aapt resource value: 0x7f070027
-			public const int abc_text_size_title_material_toolbar = 2131165223;
+			// aapt resource value: 0x7f060010
+			public const int abc_text_size_title_material_toolbar = 2131099664;
 			
-			// aapt resource value: 0x7f070071
-			public const int cardview_compat_inset_shadow = 2131165297;
+			// aapt resource value: 0x7f060009
+			public const int cardview_compat_inset_shadow = 2131099657;
 			
-			// aapt resource value: 0x7f070072
-			public const int cardview_default_elevation = 2131165298;
+			// aapt resource value: 0x7f06000a
+			public const int cardview_default_elevation = 2131099658;
 			
-			// aapt resource value: 0x7f070073
-			public const int cardview_default_radius = 2131165299;
+			// aapt resource value: 0x7f06000b
+			public const int cardview_default_radius = 2131099659;
 			
-			// aapt resource value: 0x7f07000e
-			public const int design_appbar_elevation = 2131165198;
+			// aapt resource value: 0x7f06005f
+			public const int design_appbar_elevation = 2131099743;
 			
-			// aapt resource value: 0x7f07000f
-			public const int design_bottom_sheet_modal_elevation = 2131165199;
+			// aapt resource value: 0x7f060060
+			public const int design_bottom_sheet_modal_elevation = 2131099744;
 			
-			// aapt resource value: 0x7f070010
-			public const int design_bottom_sheet_modal_peek_height = 2131165200;
+			// aapt resource value: 0x7f060061
+			public const int design_bottom_sheet_modal_peek_height = 2131099745;
 			
-			// aapt resource value: 0x7f070011
-			public const int design_fab_border_width = 2131165201;
+			// aapt resource value: 0x7f060062
+			public const int design_fab_border_width = 2131099746;
 			
-			// aapt resource value: 0x7f070012
-			public const int design_fab_elevation = 2131165202;
+			// aapt resource value: 0x7f060063
+			public const int design_fab_elevation = 2131099747;
 			
-			// aapt resource value: 0x7f070013
-			public const int design_fab_image_size = 2131165203;
+			// aapt resource value: 0x7f060064
+			public const int design_fab_image_size = 2131099748;
 			
-			// aapt resource value: 0x7f070014
-			public const int design_fab_size_mini = 2131165204;
+			// aapt resource value: 0x7f060065
+			public const int design_fab_size_mini = 2131099749;
 			
-			// aapt resource value: 0x7f070015
-			public const int design_fab_size_normal = 2131165205;
+			// aapt resource value: 0x7f060066
+			public const int design_fab_size_normal = 2131099750;
 			
-			// aapt resource value: 0x7f070016
-			public const int design_fab_translation_z_pressed = 2131165206;
+			// aapt resource value: 0x7f060067
+			public const int design_fab_translation_z_pressed = 2131099751;
 			
-			// aapt resource value: 0x7f070017
-			public const int design_navigation_elevation = 2131165207;
+			// aapt resource value: 0x7f060068
+			public const int design_navigation_elevation = 2131099752;
 			
-			// aapt resource value: 0x7f070018
-			public const int design_navigation_icon_padding = 2131165208;
+			// aapt resource value: 0x7f060069
+			public const int design_navigation_icon_padding = 2131099753;
 			
-			// aapt resource value: 0x7f070019
-			public const int design_navigation_icon_size = 2131165209;
+			// aapt resource value: 0x7f06006a
+			public const int design_navigation_icon_size = 2131099754;
 			
-			// aapt resource value: 0x7f070006
-			public const int design_navigation_max_width = 2131165190;
+			// aapt resource value: 0x7f060057
+			public const int design_navigation_max_width = 2131099735;
 			
-			// aapt resource value: 0x7f07001a
-			public const int design_navigation_padding_bottom = 2131165210;
+			// aapt resource value: 0x7f06006b
+			public const int design_navigation_padding_bottom = 2131099755;
 			
-			// aapt resource value: 0x7f07001b
-			public const int design_navigation_separator_vertical_padding = 2131165211;
+			// aapt resource value: 0x7f06006c
+			public const int design_navigation_separator_vertical_padding = 2131099756;
 			
-			// aapt resource value: 0x7f070007
-			public const int design_snackbar_action_inline_max_width = 2131165191;
+			// aapt resource value: 0x7f060058
+			public const int design_snackbar_action_inline_max_width = 2131099736;
 			
-			// aapt resource value: 0x7f070008
-			public const int design_snackbar_background_corner_radius = 2131165192;
+			// aapt resource value: 0x7f060059
+			public const int design_snackbar_background_corner_radius = 2131099737;
 			
-			// aapt resource value: 0x7f07001c
-			public const int design_snackbar_elevation = 2131165212;
+			// aapt resource value: 0x7f06006d
+			public const int design_snackbar_elevation = 2131099757;
 			
-			// aapt resource value: 0x7f070009
-			public const int design_snackbar_extra_spacing_horizontal = 2131165193;
+			// aapt resource value: 0x7f06005a
+			public const int design_snackbar_extra_spacing_horizontal = 2131099738;
 			
-			// aapt resource value: 0x7f07000a
-			public const int design_snackbar_max_width = 2131165194;
+			// aapt resource value: 0x7f06005b
+			public const int design_snackbar_max_width = 2131099739;
 			
-			// aapt resource value: 0x7f07000b
-			public const int design_snackbar_min_width = 2131165195;
+			// aapt resource value: 0x7f06005c
+			public const int design_snackbar_min_width = 2131099740;
 			
-			// aapt resource value: 0x7f07001d
-			public const int design_snackbar_padding_horizontal = 2131165213;
+			// aapt resource value: 0x7f06006e
+			public const int design_snackbar_padding_horizontal = 2131099758;
 			
-			// aapt resource value: 0x7f07001e
-			public const int design_snackbar_padding_vertical = 2131165214;
+			// aapt resource value: 0x7f06006f
+			public const int design_snackbar_padding_vertical = 2131099759;
 			
-			// aapt resource value: 0x7f07000c
-			public const int design_snackbar_padding_vertical_2lines = 2131165196;
+			// aapt resource value: 0x7f06005d
+			public const int design_snackbar_padding_vertical_2lines = 2131099741;
 			
-			// aapt resource value: 0x7f07001f
-			public const int design_snackbar_text_size = 2131165215;
+			// aapt resource value: 0x7f060070
+			public const int design_snackbar_text_size = 2131099760;
 			
-			// aapt resource value: 0x7f070020
-			public const int design_tab_max_width = 2131165216;
+			// aapt resource value: 0x7f060071
+			public const int design_tab_max_width = 2131099761;
 			
-			// aapt resource value: 0x7f07000d
-			public const int design_tab_scrollable_min_width = 2131165197;
+			// aapt resource value: 0x7f06005e
+			public const int design_tab_scrollable_min_width = 2131099742;
 			
-			// aapt resource value: 0x7f070021
-			public const int design_tab_text_size = 2131165217;
+			// aapt resource value: 0x7f060072
+			public const int design_tab_text_size = 2131099762;
 			
-			// aapt resource value: 0x7f070022
-			public const int design_tab_text_size_2line = 2131165218;
+			// aapt resource value: 0x7f060073
+			public const int design_tab_text_size_2line = 2131099763;
 			
-			// aapt resource value: 0x7f070066
-			public const int disabled_alpha_material_dark = 2131165286;
+			// aapt resource value: 0x7f06004f
+			public const int disabled_alpha_material_dark = 2131099727;
 			
-			// aapt resource value: 0x7f070067
-			public const int disabled_alpha_material_light = 2131165287;
+			// aapt resource value: 0x7f060050
+			public const int disabled_alpha_material_light = 2131099728;
 			
-			// aapt resource value: 0x7f070068
-			public const int highlight_alpha_material_colored = 2131165288;
+			// aapt resource value: 0x7f060051
+			public const int highlight_alpha_material_colored = 2131099729;
 			
-			// aapt resource value: 0x7f070069
-			public const int highlight_alpha_material_dark = 2131165289;
+			// aapt resource value: 0x7f060052
+			public const int highlight_alpha_material_dark = 2131099730;
 			
-			// aapt resource value: 0x7f07006a
-			public const int highlight_alpha_material_light = 2131165290;
+			// aapt resource value: 0x7f060053
+			public const int highlight_alpha_material_light = 2131099731;
 			
-			// aapt resource value: 0x7f07006e
-			public const int item_touch_helper_max_drag_scroll_per_frame = 2131165294;
+			// aapt resource value: 0x7f060000
+			public const int item_touch_helper_max_drag_scroll_per_frame = 2131099648;
 			
-			// aapt resource value: 0x7f07006f
-			public const int item_touch_helper_swipe_escape_max_velocity = 2131165295;
+			// aapt resource value: 0x7f060001
+			public const int item_touch_helper_swipe_escape_max_velocity = 2131099649;
 			
-			// aapt resource value: 0x7f070070
-			public const int item_touch_helper_swipe_escape_velocity = 2131165296;
+			// aapt resource value: 0x7f060002
+			public const int item_touch_helper_swipe_escape_velocity = 2131099650;
 			
-			// aapt resource value: 0x7f070000
-			public const int mr_controller_volume_group_list_item_height = 2131165184;
+			// aapt resource value: 0x7f060003
+			public const int mr_controller_volume_group_list_item_height = 2131099651;
 			
-			// aapt resource value: 0x7f070001
-			public const int mr_controller_volume_group_list_item_icon_size = 2131165185;
+			// aapt resource value: 0x7f060004
+			public const int mr_controller_volume_group_list_item_icon_size = 2131099652;
 			
-			// aapt resource value: 0x7f070002
-			public const int mr_controller_volume_group_list_max_height = 2131165186;
+			// aapt resource value: 0x7f060005
+			public const int mr_controller_volume_group_list_max_height = 2131099653;
 			
-			// aapt resource value: 0x7f070005
-			public const int mr_controller_volume_group_list_padding_top = 2131165189;
+			// aapt resource value: 0x7f060008
+			public const int mr_controller_volume_group_list_padding_top = 2131099656;
 			
-			// aapt resource value: 0x7f070003
-			public const int mr_dialog_fixed_width_major = 2131165187;
+			// aapt resource value: 0x7f060006
+			public const int mr_dialog_fixed_width_major = 2131099654;
 			
-			// aapt resource value: 0x7f070004
-			public const int mr_dialog_fixed_width_minor = 2131165188;
+			// aapt resource value: 0x7f060007
+			public const int mr_dialog_fixed_width_minor = 2131099655;
 			
-			// aapt resource value: 0x7f07006b
-			public const int notification_large_icon_height = 2131165291;
+			// aapt resource value: 0x7f060054
+			public const int notification_large_icon_height = 2131099732;
 			
-			// aapt resource value: 0x7f07006c
-			public const int notification_large_icon_width = 2131165292;
+			// aapt resource value: 0x7f060055
+			public const int notification_large_icon_width = 2131099733;
 			
-			// aapt resource value: 0x7f07006d
-			public const int notification_subtext_size = 2131165293;
+			// aapt resource value: 0x7f060056
+			public const int notification_subtext_size = 2131099734;
 			
 			static Dimension()
 			{
@@ -2219,461 +2219,461 @@ namespace CustomLayouts.Droid
 		public partial class Id
 		{
 			
-			// aapt resource value: 0x7f0b008b
-			public const int action0 = 2131427467;
+			// aapt resource value: 0x7f07008b
+			public const int action0 = 2131165323;
 			
-			// aapt resource value: 0x7f0b005a
-			public const int action_bar = 2131427418;
+			// aapt resource value: 0x7f07005a
+			public const int action_bar = 2131165274;
 			
-			// aapt resource value: 0x7f0b0001
-			public const int action_bar_activity_content = 2131427329;
+			// aapt resource value: 0x7f070001
+			public const int action_bar_activity_content = 2131165185;
 			
-			// aapt resource value: 0x7f0b0059
-			public const int action_bar_container = 2131427417;
+			// aapt resource value: 0x7f070059
+			public const int action_bar_container = 2131165273;
 			
-			// aapt resource value: 0x7f0b0055
-			public const int action_bar_root = 2131427413;
+			// aapt resource value: 0x7f070055
+			public const int action_bar_root = 2131165269;
 			
-			// aapt resource value: 0x7f0b0002
-			public const int action_bar_spinner = 2131427330;
+			// aapt resource value: 0x7f070002
+			public const int action_bar_spinner = 2131165186;
 			
-			// aapt resource value: 0x7f0b003b
-			public const int action_bar_subtitle = 2131427387;
+			// aapt resource value: 0x7f07003b
+			public const int action_bar_subtitle = 2131165243;
 			
-			// aapt resource value: 0x7f0b003a
-			public const int action_bar_title = 2131427386;
+			// aapt resource value: 0x7f07003a
+			public const int action_bar_title = 2131165242;
 			
-			// aapt resource value: 0x7f0b005b
-			public const int action_context_bar = 2131427419;
+			// aapt resource value: 0x7f07005b
+			public const int action_context_bar = 2131165275;
 			
-			// aapt resource value: 0x7f0b008f
-			public const int action_divider = 2131427471;
+			// aapt resource value: 0x7f07008f
+			public const int action_divider = 2131165327;
 			
-			// aapt resource value: 0x7f0b0003
-			public const int action_menu_divider = 2131427331;
+			// aapt resource value: 0x7f070003
+			public const int action_menu_divider = 2131165187;
 			
-			// aapt resource value: 0x7f0b0004
-			public const int action_menu_presenter = 2131427332;
+			// aapt resource value: 0x7f070004
+			public const int action_menu_presenter = 2131165188;
 			
-			// aapt resource value: 0x7f0b0057
-			public const int action_mode_bar = 2131427415;
+			// aapt resource value: 0x7f070057
+			public const int action_mode_bar = 2131165271;
 			
-			// aapt resource value: 0x7f0b0056
-			public const int action_mode_bar_stub = 2131427414;
+			// aapt resource value: 0x7f070056
+			public const int action_mode_bar_stub = 2131165270;
 			
-			// aapt resource value: 0x7f0b003c
-			public const int action_mode_close_button = 2131427388;
+			// aapt resource value: 0x7f07003c
+			public const int action_mode_close_button = 2131165244;
 			
-			// aapt resource value: 0x7f0b003d
-			public const int activity_chooser_view_content = 2131427389;
+			// aapt resource value: 0x7f07003d
+			public const int activity_chooser_view_content = 2131165245;
 			
-			// aapt resource value: 0x7f0b0049
-			public const int alertTitle = 2131427401;
+			// aapt resource value: 0x7f070049
+			public const int alertTitle = 2131165257;
 			
-			// aapt resource value: 0x7f0b0035
-			public const int always = 2131427381;
+			// aapt resource value: 0x7f07001e
+			public const int always = 2131165214;
 			
-			// aapt resource value: 0x7f0b0033
-			public const int beginning = 2131427379;
+			// aapt resource value: 0x7f07001b
+			public const int beginning = 2131165211;
 			
-			// aapt resource value: 0x7f0b0013
-			public const int bottom = 2131427347;
+			// aapt resource value: 0x7f07002a
+			public const int bottom = 2131165226;
 			
-			// aapt resource value: 0x7f0b0044
-			public const int buttonPanel = 2131427396;
+			// aapt resource value: 0x7f070044
+			public const int buttonPanel = 2131165252;
 			
-			// aapt resource value: 0x7f0b008c
-			public const int cancel_action = 2131427468;
+			// aapt resource value: 0x7f07008c
+			public const int cancel_action = 2131165324;
 			
-			// aapt resource value: 0x7f0b0014
-			public const int center = 2131427348;
+			// aapt resource value: 0x7f07002b
+			public const int center = 2131165227;
 			
-			// aapt resource value: 0x7f0b0015
-			public const int center_horizontal = 2131427349;
+			// aapt resource value: 0x7f07002c
+			public const int center_horizontal = 2131165228;
 			
-			// aapt resource value: 0x7f0b0016
-			public const int center_vertical = 2131427350;
+			// aapt resource value: 0x7f07002d
+			public const int center_vertical = 2131165229;
 			
-			// aapt resource value: 0x7f0b0052
-			public const int checkbox = 2131427410;
+			// aapt resource value: 0x7f070052
+			public const int checkbox = 2131165266;
 			
-			// aapt resource value: 0x7f0b0092
-			public const int chronometer = 2131427474;
+			// aapt resource value: 0x7f070092
+			public const int chronometer = 2131165330;
 			
-			// aapt resource value: 0x7f0b001d
-			public const int clip_horizontal = 2131427357;
+			// aapt resource value: 0x7f070033
+			public const int clip_horizontal = 2131165235;
 			
-			// aapt resource value: 0x7f0b001e
-			public const int clip_vertical = 2131427358;
+			// aapt resource value: 0x7f070034
+			public const int clip_vertical = 2131165236;
 			
-			// aapt resource value: 0x7f0b0036
-			public const int collapseActionView = 2131427382;
+			// aapt resource value: 0x7f07001f
+			public const int collapseActionView = 2131165215;
 			
-			// aapt resource value: 0x7f0b004a
-			public const int contentPanel = 2131427402;
+			// aapt resource value: 0x7f07004a
+			public const int contentPanel = 2131165258;
 			
-			// aapt resource value: 0x7f0b0050
-			public const int custom = 2131427408;
+			// aapt resource value: 0x7f070050
+			public const int custom = 2131165264;
 			
-			// aapt resource value: 0x7f0b004f
-			public const int customPanel = 2131427407;
+			// aapt resource value: 0x7f07004f
+			public const int customPanel = 2131165263;
 			
-			// aapt resource value: 0x7f0b0058
-			public const int decor_content_parent = 2131427416;
+			// aapt resource value: 0x7f070058
+			public const int decor_content_parent = 2131165272;
 			
-			// aapt resource value: 0x7f0b0040
-			public const int default_activity_button = 2131427392;
+			// aapt resource value: 0x7f070040
+			public const int default_activity_button = 2131165248;
 			
-			// aapt resource value: 0x7f0b006a
-			public const int design_bottom_sheet = 2131427434;
+			// aapt resource value: 0x7f07006a
+			public const int design_bottom_sheet = 2131165290;
 			
-			// aapt resource value: 0x7f0b0071
-			public const int design_menu_item_action_area = 2131427441;
+			// aapt resource value: 0x7f070071
+			public const int design_menu_item_action_area = 2131165297;
 			
-			// aapt resource value: 0x7f0b0070
-			public const int design_menu_item_action_area_stub = 2131427440;
+			// aapt resource value: 0x7f070070
+			public const int design_menu_item_action_area_stub = 2131165296;
 			
-			// aapt resource value: 0x7f0b006f
-			public const int design_menu_item_text = 2131427439;
+			// aapt resource value: 0x7f07006f
+			public const int design_menu_item_text = 2131165295;
 			
-			// aapt resource value: 0x7f0b006e
-			public const int design_navigation_view = 2131427438;
+			// aapt resource value: 0x7f07006e
+			public const int design_navigation_view = 2131165294;
 			
-			// aapt resource value: 0x7f0b0027
-			public const int disableHome = 2131427367;
+			// aapt resource value: 0x7f07000e
+			public const int disableHome = 2131165198;
 			
-			// aapt resource value: 0x7f0b005c
-			public const int edit_query = 2131427420;
+			// aapt resource value: 0x7f07005c
+			public const int edit_query = 2131165276;
 			
-			// aapt resource value: 0x7f0b0017
-			public const int end = 2131427351;
+			// aapt resource value: 0x7f07001c
+			public const int end = 2131165212;
 			
-			// aapt resource value: 0x7f0b0097
-			public const int end_padder = 2131427479;
+			// aapt resource value: 0x7f070097
+			public const int end_padder = 2131165335;
 			
-			// aapt resource value: 0x7f0b000b
-			public const int enterAlways = 2131427339;
+			// aapt resource value: 0x7f070023
+			public const int enterAlways = 2131165219;
 			
-			// aapt resource value: 0x7f0b000c
-			public const int enterAlwaysCollapsed = 2131427340;
+			// aapt resource value: 0x7f070024
+			public const int enterAlwaysCollapsed = 2131165220;
 			
-			// aapt resource value: 0x7f0b000d
-			public const int exitUntilCollapsed = 2131427341;
+			// aapt resource value: 0x7f070025
+			public const int exitUntilCollapsed = 2131165221;
 			
-			// aapt resource value: 0x7f0b003e
-			public const int expand_activities_button = 2131427390;
+			// aapt resource value: 0x7f07003e
+			public const int expand_activities_button = 2131165246;
 			
-			// aapt resource value: 0x7f0b0051
-			public const int expanded_menu = 2131427409;
+			// aapt resource value: 0x7f070051
+			public const int expanded_menu = 2131165265;
 			
-			// aapt resource value: 0x7f0b001f
-			public const int fill = 2131427359;
+			// aapt resource value: 0x7f070035
+			public const int fill = 2131165237;
 			
-			// aapt resource value: 0x7f0b0020
-			public const int fill_horizontal = 2131427360;
+			// aapt resource value: 0x7f070036
+			public const int fill_horizontal = 2131165238;
 			
-			// aapt resource value: 0x7f0b0018
-			public const int fill_vertical = 2131427352;
+			// aapt resource value: 0x7f07002e
+			public const int fill_vertical = 2131165230;
 			
-			// aapt resource value: 0x7f0b0023
-			public const int @fixed = 2131427363;
+			// aapt resource value: 0x7f070038
+			public const int @fixed = 2131165240;
 			
-			// aapt resource value: 0x7f0b0005
-			public const int home = 2131427333;
+			// aapt resource value: 0x7f070005
+			public const int home = 2131165189;
 			
-			// aapt resource value: 0x7f0b0028
-			public const int homeAsUp = 2131427368;
+			// aapt resource value: 0x7f07000f
+			public const int homeAsUp = 2131165199;
 			
-			// aapt resource value: 0x7f0b0042
-			public const int icon = 2131427394;
+			// aapt resource value: 0x7f070042
+			public const int icon = 2131165250;
 			
-			// aapt resource value: 0x7f0b0037
-			public const int ifRoom = 2131427383;
+			// aapt resource value: 0x7f070020
+			public const int ifRoom = 2131165216;
 			
-			// aapt resource value: 0x7f0b003f
-			public const int image = 2131427391;
+			// aapt resource value: 0x7f07003f
+			public const int image = 2131165247;
 			
-			// aapt resource value: 0x7f0b0096
-			public const int info = 2131427478;
+			// aapt resource value: 0x7f070096
+			public const int info = 2131165334;
 			
-			// aapt resource value: 0x7f0b000a
-			public const int item_touch_helper_previous_elevation = 2131427338;
+			// aapt resource value: 0x7f070000
+			public const int item_touch_helper_previous_elevation = 2131165184;
 			
-			// aapt resource value: 0x7f0b0019
-			public const int left = 2131427353;
+			// aapt resource value: 0x7f07002f
+			public const int left = 2131165231;
 			
-			// aapt resource value: 0x7f0b0090
-			public const int line1 = 2131427472;
+			// aapt resource value: 0x7f070090
+			public const int line1 = 2131165328;
 			
-			// aapt resource value: 0x7f0b0094
-			public const int line3 = 2131427476;
+			// aapt resource value: 0x7f070094
+			public const int line3 = 2131165332;
 			
-			// aapt resource value: 0x7f0b0025
-			public const int listMode = 2131427365;
+			// aapt resource value: 0x7f07000b
+			public const int listMode = 2131165195;
 			
-			// aapt resource value: 0x7f0b0041
-			public const int list_item = 2131427393;
+			// aapt resource value: 0x7f070041
+			public const int list_item = 2131165249;
 			
-			// aapt resource value: 0x7f0b008e
-			public const int media_actions = 2131427470;
+			// aapt resource value: 0x7f07008e
+			public const int media_actions = 2131165326;
 			
-			// aapt resource value: 0x7f0b0034
-			public const int middle = 2131427380;
+			// aapt resource value: 0x7f07001d
+			public const int middle = 2131165213;
 			
-			// aapt resource value: 0x7f0b0021
-			public const int mini = 2131427361;
+			// aapt resource value: 0x7f070037
+			public const int mini = 2131165239;
 			
-			// aapt resource value: 0x7f0b007d
-			public const int mr_art = 2131427453;
+			// aapt resource value: 0x7f07007d
+			public const int mr_art = 2131165309;
 			
-			// aapt resource value: 0x7f0b0072
-			public const int mr_chooser_list = 2131427442;
+			// aapt resource value: 0x7f070072
+			public const int mr_chooser_list = 2131165298;
 			
-			// aapt resource value: 0x7f0b0075
-			public const int mr_chooser_route_desc = 2131427445;
+			// aapt resource value: 0x7f070075
+			public const int mr_chooser_route_desc = 2131165301;
 			
-			// aapt resource value: 0x7f0b0073
-			public const int mr_chooser_route_icon = 2131427443;
+			// aapt resource value: 0x7f070073
+			public const int mr_chooser_route_icon = 2131165299;
 			
-			// aapt resource value: 0x7f0b0074
-			public const int mr_chooser_route_name = 2131427444;
+			// aapt resource value: 0x7f070074
+			public const int mr_chooser_route_name = 2131165300;
 			
-			// aapt resource value: 0x7f0b007a
-			public const int mr_close = 2131427450;
+			// aapt resource value: 0x7f07007a
+			public const int mr_close = 2131165306;
 			
-			// aapt resource value: 0x7f0b0080
-			public const int mr_control_divider = 2131427456;
+			// aapt resource value: 0x7f070080
+			public const int mr_control_divider = 2131165312;
 			
-			// aapt resource value: 0x7f0b0086
-			public const int mr_control_play_pause = 2131427462;
+			// aapt resource value: 0x7f070086
+			public const int mr_control_play_pause = 2131165318;
 			
-			// aapt resource value: 0x7f0b0089
-			public const int mr_control_subtitle = 2131427465;
+			// aapt resource value: 0x7f070089
+			public const int mr_control_subtitle = 2131165321;
 			
-			// aapt resource value: 0x7f0b0088
-			public const int mr_control_title = 2131427464;
+			// aapt resource value: 0x7f070088
+			public const int mr_control_title = 2131165320;
 			
-			// aapt resource value: 0x7f0b0087
-			public const int mr_control_title_container = 2131427463;
+			// aapt resource value: 0x7f070087
+			public const int mr_control_title_container = 2131165319;
 			
-			// aapt resource value: 0x7f0b007b
-			public const int mr_custom_control = 2131427451;
+			// aapt resource value: 0x7f07007b
+			public const int mr_custom_control = 2131165307;
 			
-			// aapt resource value: 0x7f0b007c
-			public const int mr_default_control = 2131427452;
+			// aapt resource value: 0x7f07007c
+			public const int mr_default_control = 2131165308;
 			
-			// aapt resource value: 0x7f0b0077
-			public const int mr_dialog_area = 2131427447;
+			// aapt resource value: 0x7f070077
+			public const int mr_dialog_area = 2131165303;
 			
-			// aapt resource value: 0x7f0b0076
-			public const int mr_expandable_area = 2131427446;
+			// aapt resource value: 0x7f070076
+			public const int mr_expandable_area = 2131165302;
 			
-			// aapt resource value: 0x7f0b008a
-			public const int mr_group_expand_collapse = 2131427466;
+			// aapt resource value: 0x7f07008a
+			public const int mr_group_expand_collapse = 2131165322;
 			
-			// aapt resource value: 0x7f0b007e
-			public const int mr_media_main_control = 2131427454;
+			// aapt resource value: 0x7f07007e
+			public const int mr_media_main_control = 2131165310;
 			
-			// aapt resource value: 0x7f0b0079
-			public const int mr_name = 2131427449;
+			// aapt resource value: 0x7f070079
+			public const int mr_name = 2131165305;
 			
-			// aapt resource value: 0x7f0b007f
-			public const int mr_playback_control = 2131427455;
+			// aapt resource value: 0x7f07007f
+			public const int mr_playback_control = 2131165311;
 			
-			// aapt resource value: 0x7f0b0078
-			public const int mr_title_bar = 2131427448;
+			// aapt resource value: 0x7f070078
+			public const int mr_title_bar = 2131165304;
 			
-			// aapt resource value: 0x7f0b0081
-			public const int mr_volume_control = 2131427457;
+			// aapt resource value: 0x7f070081
+			public const int mr_volume_control = 2131165313;
 			
-			// aapt resource value: 0x7f0b0082
-			public const int mr_volume_group_list = 2131427458;
+			// aapt resource value: 0x7f070082
+			public const int mr_volume_group_list = 2131165314;
 			
-			// aapt resource value: 0x7f0b0084
-			public const int mr_volume_item_icon = 2131427460;
+			// aapt resource value: 0x7f070084
+			public const int mr_volume_item_icon = 2131165316;
 			
-			// aapt resource value: 0x7f0b0085
-			public const int mr_volume_slider = 2131427461;
+			// aapt resource value: 0x7f070085
+			public const int mr_volume_slider = 2131165317;
 			
-			// aapt resource value: 0x7f0b002e
-			public const int multiply = 2131427374;
+			// aapt resource value: 0x7f070016
+			public const int multiply = 2131165206;
 			
-			// aapt resource value: 0x7f0b006d
-			public const int navigation_header_container = 2131427437;
+			// aapt resource value: 0x7f07006d
+			public const int navigation_header_container = 2131165293;
 			
-			// aapt resource value: 0x7f0b0038
-			public const int never = 2131427384;
+			// aapt resource value: 0x7f070021
+			public const int never = 2131165217;
 			
-			// aapt resource value: 0x7f0b0010
-			public const int none = 2131427344;
+			// aapt resource value: 0x7f070010
+			public const int none = 2131165200;
 			
-			// aapt resource value: 0x7f0b0022
-			public const int normal = 2131427362;
+			// aapt resource value: 0x7f07000c
+			public const int normal = 2131165196;
 			
-			// aapt resource value: 0x7f0b0011
-			public const int parallax = 2131427345;
+			// aapt resource value: 0x7f070028
+			public const int parallax = 2131165224;
 			
-			// aapt resource value: 0x7f0b0046
-			public const int parentPanel = 2131427398;
+			// aapt resource value: 0x7f070046
+			public const int parentPanel = 2131165254;
 			
-			// aapt resource value: 0x7f0b0012
-			public const int pin = 2131427346;
+			// aapt resource value: 0x7f070029
+			public const int pin = 2131165225;
 			
-			// aapt resource value: 0x7f0b0006
-			public const int progress_circular = 2131427334;
+			// aapt resource value: 0x7f070006
+			public const int progress_circular = 2131165190;
 			
-			// aapt resource value: 0x7f0b0007
-			public const int progress_horizontal = 2131427335;
+			// aapt resource value: 0x7f070007
+			public const int progress_horizontal = 2131165191;
 			
-			// aapt resource value: 0x7f0b0054
-			public const int radio = 2131427412;
+			// aapt resource value: 0x7f070054
+			public const int radio = 2131165268;
 			
-			// aapt resource value: 0x7f0b001a
-			public const int right = 2131427354;
+			// aapt resource value: 0x7f070030
+			public const int right = 2131165232;
 			
-			// aapt resource value: 0x7f0b002f
-			public const int screen = 2131427375;
+			// aapt resource value: 0x7f070017
+			public const int screen = 2131165207;
 			
-			// aapt resource value: 0x7f0b000e
-			public const int scroll = 2131427342;
+			// aapt resource value: 0x7f070026
+			public const int scroll = 2131165222;
 			
-			// aapt resource value: 0x7f0b004e
-			public const int scrollIndicatorDown = 2131427406;
+			// aapt resource value: 0x7f07004e
+			public const int scrollIndicatorDown = 2131165262;
 			
-			// aapt resource value: 0x7f0b004b
-			public const int scrollIndicatorUp = 2131427403;
+			// aapt resource value: 0x7f07004b
+			public const int scrollIndicatorUp = 2131165259;
 			
-			// aapt resource value: 0x7f0b004c
-			public const int scrollView = 2131427404;
+			// aapt resource value: 0x7f07004c
+			public const int scrollView = 2131165260;
 			
-			// aapt resource value: 0x7f0b0024
-			public const int scrollable = 2131427364;
+			// aapt resource value: 0x7f070039
+			public const int scrollable = 2131165241;
 			
-			// aapt resource value: 0x7f0b005e
-			public const int search_badge = 2131427422;
+			// aapt resource value: 0x7f07005e
+			public const int search_badge = 2131165278;
 			
-			// aapt resource value: 0x7f0b005d
-			public const int search_bar = 2131427421;
+			// aapt resource value: 0x7f07005d
+			public const int search_bar = 2131165277;
 			
-			// aapt resource value: 0x7f0b005f
-			public const int search_button = 2131427423;
+			// aapt resource value: 0x7f07005f
+			public const int search_button = 2131165279;
 			
-			// aapt resource value: 0x7f0b0064
-			public const int search_close_btn = 2131427428;
+			// aapt resource value: 0x7f070064
+			public const int search_close_btn = 2131165284;
 			
-			// aapt resource value: 0x7f0b0060
-			public const int search_edit_frame = 2131427424;
+			// aapt resource value: 0x7f070060
+			public const int search_edit_frame = 2131165280;
 			
-			// aapt resource value: 0x7f0b0066
-			public const int search_go_btn = 2131427430;
+			// aapt resource value: 0x7f070066
+			public const int search_go_btn = 2131165286;
 			
-			// aapt resource value: 0x7f0b0061
-			public const int search_mag_icon = 2131427425;
+			// aapt resource value: 0x7f070061
+			public const int search_mag_icon = 2131165281;
 			
-			// aapt resource value: 0x7f0b0062
-			public const int search_plate = 2131427426;
+			// aapt resource value: 0x7f070062
+			public const int search_plate = 2131165282;
 			
-			// aapt resource value: 0x7f0b0063
-			public const int search_src_text = 2131427427;
+			// aapt resource value: 0x7f070063
+			public const int search_src_text = 2131165283;
 			
-			// aapt resource value: 0x7f0b0067
-			public const int search_voice_btn = 2131427431;
+			// aapt resource value: 0x7f070067
+			public const int search_voice_btn = 2131165287;
 			
-			// aapt resource value: 0x7f0b0068
-			public const int select_dialog_listview = 2131427432;
+			// aapt resource value: 0x7f070068
+			public const int select_dialog_listview = 2131165288;
 			
-			// aapt resource value: 0x7f0b0053
-			public const int shortcut = 2131427411;
+			// aapt resource value: 0x7f070053
+			public const int shortcut = 2131165267;
 			
-			// aapt resource value: 0x7f0b0029
-			public const int showCustom = 2131427369;
+			// aapt resource value: 0x7f070011
+			public const int showCustom = 2131165201;
 			
-			// aapt resource value: 0x7f0b002a
-			public const int showHome = 2131427370;
+			// aapt resource value: 0x7f070012
+			public const int showHome = 2131165202;
 			
-			// aapt resource value: 0x7f0b002b
-			public const int showTitle = 2131427371;
+			// aapt resource value: 0x7f070013
+			public const int showTitle = 2131165203;
 			
-			// aapt resource value: 0x7f0b006c
-			public const int snackbar_action = 2131427436;
+			// aapt resource value: 0x7f07006c
+			public const int snackbar_action = 2131165292;
 			
-			// aapt resource value: 0x7f0b006b
-			public const int snackbar_text = 2131427435;
+			// aapt resource value: 0x7f07006b
+			public const int snackbar_text = 2131165291;
 			
-			// aapt resource value: 0x7f0b000f
-			public const int snap = 2131427343;
+			// aapt resource value: 0x7f070027
+			public const int snap = 2131165223;
 			
-			// aapt resource value: 0x7f0b0045
-			public const int spacer = 2131427397;
+			// aapt resource value: 0x7f070045
+			public const int spacer = 2131165253;
 			
-			// aapt resource value: 0x7f0b0008
-			public const int split_action_bar = 2131427336;
+			// aapt resource value: 0x7f070008
+			public const int split_action_bar = 2131165192;
 			
-			// aapt resource value: 0x7f0b0030
-			public const int src_atop = 2131427376;
+			// aapt resource value: 0x7f070018
+			public const int src_atop = 2131165208;
 			
-			// aapt resource value: 0x7f0b0031
-			public const int src_in = 2131427377;
+			// aapt resource value: 0x7f070019
+			public const int src_in = 2131165209;
 			
-			// aapt resource value: 0x7f0b0032
-			public const int src_over = 2131427378;
+			// aapt resource value: 0x7f07001a
+			public const int src_over = 2131165210;
 			
-			// aapt resource value: 0x7f0b001b
-			public const int start = 2131427355;
+			// aapt resource value: 0x7f070031
+			public const int start = 2131165233;
 			
-			// aapt resource value: 0x7f0b008d
-			public const int status_bar_latest_event_content = 2131427469;
+			// aapt resource value: 0x7f07008d
+			public const int status_bar_latest_event_content = 2131165325;
 			
-			// aapt resource value: 0x7f0b0065
-			public const int submit_area = 2131427429;
+			// aapt resource value: 0x7f070065
+			public const int submit_area = 2131165285;
 			
-			// aapt resource value: 0x7f0b0026
-			public const int tabMode = 2131427366;
+			// aapt resource value: 0x7f07000d
+			public const int tabMode = 2131165197;
 			
-			// aapt resource value: 0x7f0b0095
-			public const int text = 2131427477;
+			// aapt resource value: 0x7f070095
+			public const int text = 2131165333;
 			
-			// aapt resource value: 0x7f0b0093
-			public const int text2 = 2131427475;
+			// aapt resource value: 0x7f070093
+			public const int text2 = 2131165331;
 			
-			// aapt resource value: 0x7f0b004d
-			public const int textSpacerNoButtons = 2131427405;
+			// aapt resource value: 0x7f07004d
+			public const int textSpacerNoButtons = 2131165261;
 			
-			// aapt resource value: 0x7f0b0091
-			public const int time = 2131427473;
+			// aapt resource value: 0x7f070091
+			public const int time = 2131165329;
 			
-			// aapt resource value: 0x7f0b0043
-			public const int title = 2131427395;
+			// aapt resource value: 0x7f070043
+			public const int title = 2131165251;
 			
-			// aapt resource value: 0x7f0b0048
-			public const int title_template = 2131427400;
+			// aapt resource value: 0x7f070048
+			public const int title_template = 2131165256;
 			
-			// aapt resource value: 0x7f0b001c
-			public const int top = 2131427356;
+			// aapt resource value: 0x7f070032
+			public const int top = 2131165234;
 			
-			// aapt resource value: 0x7f0b0047
-			public const int topPanel = 2131427399;
+			// aapt resource value: 0x7f070047
+			public const int topPanel = 2131165255;
 			
-			// aapt resource value: 0x7f0b0069
-			public const int touch_outside = 2131427433;
+			// aapt resource value: 0x7f070069
+			public const int touch_outside = 2131165289;
 			
-			// aapt resource value: 0x7f0b0009
-			public const int up = 2131427337;
+			// aapt resource value: 0x7f070009
+			public const int up = 2131165193;
 			
-			// aapt resource value: 0x7f0b002c
-			public const int useLogo = 2131427372;
+			// aapt resource value: 0x7f070014
+			public const int useLogo = 2131165204;
 			
-			// aapt resource value: 0x7f0b0000
-			public const int view_offset_helper = 2131427328;
+			// aapt resource value: 0x7f07000a
+			public const int view_offset_helper = 2131165194;
 			
-			// aapt resource value: 0x7f0b0083
-			public const int volume_item_container = 2131427459;
+			// aapt resource value: 0x7f070083
+			public const int volume_item_container = 2131165315;
 			
-			// aapt resource value: 0x7f0b0039
-			public const int withText = 2131427385;
+			// aapt resource value: 0x7f070022
+			public const int withText = 2131165218;
 			
-			// aapt resource value: 0x7f0b002d
-			public const int wrap_content = 2131427373;
+			// aapt resource value: 0x7f070015
+			public const int wrap_content = 2131165205;
 			
 			static Id()
 			{
@@ -2688,35 +2688,35 @@ namespace CustomLayouts.Droid
 		public partial class Integer
 		{
 			
-			// aapt resource value: 0x7f080006
-			public const int abc_config_activityDefaultDur = 2131230726;
+			// aapt resource value: 0x7f090004
+			public const int abc_config_activityDefaultDur = 2131296260;
 			
-			// aapt resource value: 0x7f080007
-			public const int abc_config_activityShortDur = 2131230727;
+			// aapt resource value: 0x7f090005
+			public const int abc_config_activityShortDur = 2131296261;
 			
-			// aapt resource value: 0x7f080005
-			public const int abc_max_action_buttons = 2131230725;
+			// aapt resource value: 0x7f090003
+			public const int abc_max_action_buttons = 2131296259;
 			
-			// aapt resource value: 0x7f080004
-			public const int bottom_sheet_slide_duration = 2131230724;
+			// aapt resource value: 0x7f090009
+			public const int bottom_sheet_slide_duration = 2131296265;
 			
-			// aapt resource value: 0x7f080008
-			public const int cancel_button_image_alpha = 2131230728;
+			// aapt resource value: 0x7f090006
+			public const int cancel_button_image_alpha = 2131296262;
 			
-			// aapt resource value: 0x7f080003
-			public const int design_snackbar_text_max_lines = 2131230723;
+			// aapt resource value: 0x7f090008
+			public const int design_snackbar_text_max_lines = 2131296264;
 			
-			// aapt resource value: 0x7f080000
-			public const int mr_controller_volume_group_list_animation_duration_ms = 2131230720;
+			// aapt resource value: 0x7f090000
+			public const int mr_controller_volume_group_list_animation_duration_ms = 2131296256;
 			
-			// aapt resource value: 0x7f080001
-			public const int mr_controller_volume_group_list_fade_in_duration_ms = 2131230721;
+			// aapt resource value: 0x7f090001
+			public const int mr_controller_volume_group_list_fade_in_duration_ms = 2131296257;
 			
-			// aapt resource value: 0x7f080002
-			public const int mr_controller_volume_group_list_fade_out_duration_ms = 2131230722;
+			// aapt resource value: 0x7f090002
+			public const int mr_controller_volume_group_list_fade_out_duration_ms = 2131296258;
 			
-			// aapt resource value: 0x7f080009
-			public const int status_bar_notification_info_maxnum = 2131230729;
+			// aapt resource value: 0x7f090007
+			public const int status_bar_notification_info_maxnum = 2131296263;
 			
 			static Integer()
 			{
@@ -2928,119 +2928,119 @@ namespace CustomLayouts.Droid
 		public partial class String
 		{
 			
-			// aapt resource value: 0x7f060012
-			public const int abc_action_bar_home_description = 2131099666;
+			// aapt resource value: 0x7f08000f
+			public const int abc_action_bar_home_description = 2131230735;
 			
-			// aapt resource value: 0x7f060013
-			public const int abc_action_bar_home_description_format = 2131099667;
+			// aapt resource value: 0x7f080010
+			public const int abc_action_bar_home_description_format = 2131230736;
 			
-			// aapt resource value: 0x7f060014
-			public const int abc_action_bar_home_subtitle_description_format = 2131099668;
+			// aapt resource value: 0x7f080011
+			public const int abc_action_bar_home_subtitle_description_format = 2131230737;
 			
-			// aapt resource value: 0x7f060015
-			public const int abc_action_bar_up_description = 2131099669;
+			// aapt resource value: 0x7f080012
+			public const int abc_action_bar_up_description = 2131230738;
 			
-			// aapt resource value: 0x7f060016
-			public const int abc_action_menu_overflow_description = 2131099670;
+			// aapt resource value: 0x7f080013
+			public const int abc_action_menu_overflow_description = 2131230739;
 			
-			// aapt resource value: 0x7f060017
-			public const int abc_action_mode_done = 2131099671;
+			// aapt resource value: 0x7f080014
+			public const int abc_action_mode_done = 2131230740;
 			
-			// aapt resource value: 0x7f060018
-			public const int abc_activity_chooser_view_see_all = 2131099672;
+			// aapt resource value: 0x7f080015
+			public const int abc_activity_chooser_view_see_all = 2131230741;
 			
-			// aapt resource value: 0x7f060019
-			public const int abc_activitychooserview_choose_application = 2131099673;
+			// aapt resource value: 0x7f080016
+			public const int abc_activitychooserview_choose_application = 2131230742;
 			
-			// aapt resource value: 0x7f06001a
-			public const int abc_capital_off = 2131099674;
+			// aapt resource value: 0x7f080017
+			public const int abc_capital_off = 2131230743;
 			
-			// aapt resource value: 0x7f06001b
-			public const int abc_capital_on = 2131099675;
+			// aapt resource value: 0x7f080018
+			public const int abc_capital_on = 2131230744;
 			
-			// aapt resource value: 0x7f06001c
-			public const int abc_search_hint = 2131099676;
+			// aapt resource value: 0x7f080019
+			public const int abc_search_hint = 2131230745;
 			
-			// aapt resource value: 0x7f06001d
-			public const int abc_searchview_description_clear = 2131099677;
+			// aapt resource value: 0x7f08001a
+			public const int abc_searchview_description_clear = 2131230746;
 			
-			// aapt resource value: 0x7f06001e
-			public const int abc_searchview_description_query = 2131099678;
+			// aapt resource value: 0x7f08001b
+			public const int abc_searchview_description_query = 2131230747;
 			
-			// aapt resource value: 0x7f06001f
-			public const int abc_searchview_description_search = 2131099679;
+			// aapt resource value: 0x7f08001c
+			public const int abc_searchview_description_search = 2131230748;
 			
-			// aapt resource value: 0x7f060020
-			public const int abc_searchview_description_submit = 2131099680;
+			// aapt resource value: 0x7f08001d
+			public const int abc_searchview_description_submit = 2131230749;
 			
-			// aapt resource value: 0x7f060021
-			public const int abc_searchview_description_voice = 2131099681;
+			// aapt resource value: 0x7f08001e
+			public const int abc_searchview_description_voice = 2131230750;
 			
-			// aapt resource value: 0x7f060022
-			public const int abc_shareactionprovider_share_with = 2131099682;
+			// aapt resource value: 0x7f08001f
+			public const int abc_shareactionprovider_share_with = 2131230751;
 			
-			// aapt resource value: 0x7f060023
-			public const int abc_shareactionprovider_share_with_application = 2131099683;
+			// aapt resource value: 0x7f080020
+			public const int abc_shareactionprovider_share_with_application = 2131230752;
 			
-			// aapt resource value: 0x7f060024
-			public const int abc_toolbar_collapse_description = 2131099684;
+			// aapt resource value: 0x7f080021
+			public const int abc_toolbar_collapse_description = 2131230753;
 			
-			// aapt resource value: 0x7f06000f
-			public const int appbar_scrolling_view_behavior = 2131099663;
+			// aapt resource value: 0x7f080023
+			public const int appbar_scrolling_view_behavior = 2131230755;
 			
-			// aapt resource value: 0x7f060010
-			public const int bottom_sheet_behavior = 2131099664;
+			// aapt resource value: 0x7f080024
+			public const int bottom_sheet_behavior = 2131230756;
 			
-			// aapt resource value: 0x7f060011
-			public const int character_counter_pattern = 2131099665;
+			// aapt resource value: 0x7f080025
+			public const int character_counter_pattern = 2131230757;
 			
-			// aapt resource value: 0x7f060000
-			public const int mr_button_content_description = 2131099648;
+			// aapt resource value: 0x7f080000
+			public const int mr_button_content_description = 2131230720;
 			
-			// aapt resource value: 0x7f060001
-			public const int mr_chooser_searching = 2131099649;
+			// aapt resource value: 0x7f080001
+			public const int mr_chooser_searching = 2131230721;
 			
-			// aapt resource value: 0x7f060002
-			public const int mr_chooser_title = 2131099650;
+			// aapt resource value: 0x7f080002
+			public const int mr_chooser_title = 2131230722;
 			
-			// aapt resource value: 0x7f060003
-			public const int mr_controller_casting_screen = 2131099651;
+			// aapt resource value: 0x7f080003
+			public const int mr_controller_casting_screen = 2131230723;
 			
-			// aapt resource value: 0x7f060004
-			public const int mr_controller_close_description = 2131099652;
+			// aapt resource value: 0x7f080004
+			public const int mr_controller_close_description = 2131230724;
 			
-			// aapt resource value: 0x7f060005
-			public const int mr_controller_collapse_group = 2131099653;
+			// aapt resource value: 0x7f080005
+			public const int mr_controller_collapse_group = 2131230725;
 			
-			// aapt resource value: 0x7f060006
-			public const int mr_controller_disconnect = 2131099654;
+			// aapt resource value: 0x7f080006
+			public const int mr_controller_disconnect = 2131230726;
 			
-			// aapt resource value: 0x7f060007
-			public const int mr_controller_expand_group = 2131099655;
+			// aapt resource value: 0x7f080007
+			public const int mr_controller_expand_group = 2131230727;
 			
-			// aapt resource value: 0x7f060008
-			public const int mr_controller_no_info_available = 2131099656;
+			// aapt resource value: 0x7f080008
+			public const int mr_controller_no_info_available = 2131230728;
 			
-			// aapt resource value: 0x7f060009
-			public const int mr_controller_no_media_selected = 2131099657;
+			// aapt resource value: 0x7f080009
+			public const int mr_controller_no_media_selected = 2131230729;
 			
-			// aapt resource value: 0x7f06000a
-			public const int mr_controller_pause = 2131099658;
+			// aapt resource value: 0x7f08000a
+			public const int mr_controller_pause = 2131230730;
 			
-			// aapt resource value: 0x7f06000b
-			public const int mr_controller_play = 2131099659;
+			// aapt resource value: 0x7f08000b
+			public const int mr_controller_play = 2131230731;
 			
-			// aapt resource value: 0x7f06000c
-			public const int mr_controller_stop = 2131099660;
+			// aapt resource value: 0x7f08000c
+			public const int mr_controller_stop = 2131230732;
 			
-			// aapt resource value: 0x7f06000d
-			public const int mr_system_route_name = 2131099661;
+			// aapt resource value: 0x7f08000d
+			public const int mr_system_route_name = 2131230733;
 			
-			// aapt resource value: 0x7f06000e
-			public const int mr_user_route_category_name = 2131099662;
+			// aapt resource value: 0x7f08000e
+			public const int mr_user_route_category_name = 2131230734;
 			
-			// aapt resource value: 0x7f060025
-			public const int status_bar_notification_info_overflow = 2131099685;
+			// aapt resource value: 0x7f080022
+			public const int status_bar_notification_info_overflow = 2131230754;
 			
 			static String()
 			{
@@ -3055,1115 +3055,1115 @@ namespace CustomLayouts.Droid
 		public partial class Style
 		{
 			
-			// aapt resource value: 0x7f0900b6
-			public const int AlertDialog_AppCompat = 2131296438;
+			// aapt resource value: 0x7f0a00a1
+			public const int AlertDialog_AppCompat = 2131361953;
 			
-			// aapt resource value: 0x7f0900b7
-			public const int AlertDialog_AppCompat_Light = 2131296439;
+			// aapt resource value: 0x7f0a00a2
+			public const int AlertDialog_AppCompat_Light = 2131361954;
 			
-			// aapt resource value: 0x7f0900b8
-			public const int Animation_AppCompat_Dialog = 2131296440;
+			// aapt resource value: 0x7f0a00a3
+			public const int Animation_AppCompat_Dialog = 2131361955;
 			
-			// aapt resource value: 0x7f0900b9
-			public const int Animation_AppCompat_DropDownUp = 2131296441;
+			// aapt resource value: 0x7f0a00a4
+			public const int Animation_AppCompat_DropDownUp = 2131361956;
 			
-			// aapt resource value: 0x7f090018
-			public const int Animation_Design_BottomSheetDialog = 2131296280;
+			// aapt resource value: 0x7f0a015a
+			public const int Animation_Design_BottomSheetDialog = 2131362138;
 			
-			// aapt resource value: 0x7f0900ba
-			public const int Base_AlertDialog_AppCompat = 2131296442;
+			// aapt resource value: 0x7f0a00a5
+			public const int Base_AlertDialog_AppCompat = 2131361957;
 			
-			// aapt resource value: 0x7f0900bb
-			public const int Base_AlertDialog_AppCompat_Light = 2131296443;
+			// aapt resource value: 0x7f0a00a6
+			public const int Base_AlertDialog_AppCompat_Light = 2131361958;
 			
-			// aapt resource value: 0x7f0900bc
-			public const int Base_Animation_AppCompat_Dialog = 2131296444;
+			// aapt resource value: 0x7f0a00a7
+			public const int Base_Animation_AppCompat_Dialog = 2131361959;
 			
-			// aapt resource value: 0x7f0900bd
-			public const int Base_Animation_AppCompat_DropDownUp = 2131296445;
+			// aapt resource value: 0x7f0a00a8
+			public const int Base_Animation_AppCompat_DropDownUp = 2131361960;
 			
-			// aapt resource value: 0x7f09016f
-			public const int Base_CardView = 2131296623;
+			// aapt resource value: 0x7f0a0018
+			public const int Base_CardView = 2131361816;
 			
-			// aapt resource value: 0x7f0900be
-			public const int Base_DialogWindowTitle_AppCompat = 2131296446;
+			// aapt resource value: 0x7f0a00a9
+			public const int Base_DialogWindowTitle_AppCompat = 2131361961;
 			
-			// aapt resource value: 0x7f0900bf
-			public const int Base_DialogWindowTitleBackground_AppCompat = 2131296447;
+			// aapt resource value: 0x7f0a00aa
+			public const int Base_DialogWindowTitleBackground_AppCompat = 2131361962;
 			
-			// aapt resource value: 0x7f090066
-			public const int Base_TextAppearance_AppCompat = 2131296358;
+			// aapt resource value: 0x7f0a0051
+			public const int Base_TextAppearance_AppCompat = 2131361873;
 			
-			// aapt resource value: 0x7f090067
-			public const int Base_TextAppearance_AppCompat_Body1 = 2131296359;
+			// aapt resource value: 0x7f0a0052
+			public const int Base_TextAppearance_AppCompat_Body1 = 2131361874;
 			
-			// aapt resource value: 0x7f090068
-			public const int Base_TextAppearance_AppCompat_Body2 = 2131296360;
+			// aapt resource value: 0x7f0a0053
+			public const int Base_TextAppearance_AppCompat_Body2 = 2131361875;
 			
-			// aapt resource value: 0x7f090050
-			public const int Base_TextAppearance_AppCompat_Button = 2131296336;
+			// aapt resource value: 0x7f0a003b
+			public const int Base_TextAppearance_AppCompat_Button = 2131361851;
 			
-			// aapt resource value: 0x7f090069
-			public const int Base_TextAppearance_AppCompat_Caption = 2131296361;
+			// aapt resource value: 0x7f0a0054
+			public const int Base_TextAppearance_AppCompat_Caption = 2131361876;
 			
-			// aapt resource value: 0x7f09006a
-			public const int Base_TextAppearance_AppCompat_Display1 = 2131296362;
+			// aapt resource value: 0x7f0a0055
+			public const int Base_TextAppearance_AppCompat_Display1 = 2131361877;
 			
-			// aapt resource value: 0x7f09006b
-			public const int Base_TextAppearance_AppCompat_Display2 = 2131296363;
+			// aapt resource value: 0x7f0a0056
+			public const int Base_TextAppearance_AppCompat_Display2 = 2131361878;
 			
-			// aapt resource value: 0x7f09006c
-			public const int Base_TextAppearance_AppCompat_Display3 = 2131296364;
+			// aapt resource value: 0x7f0a0057
+			public const int Base_TextAppearance_AppCompat_Display3 = 2131361879;
 			
-			// aapt resource value: 0x7f09006d
-			public const int Base_TextAppearance_AppCompat_Display4 = 2131296365;
+			// aapt resource value: 0x7f0a0058
+			public const int Base_TextAppearance_AppCompat_Display4 = 2131361880;
 			
-			// aapt resource value: 0x7f09006e
-			public const int Base_TextAppearance_AppCompat_Headline = 2131296366;
+			// aapt resource value: 0x7f0a0059
+			public const int Base_TextAppearance_AppCompat_Headline = 2131361881;
 			
-			// aapt resource value: 0x7f09003b
-			public const int Base_TextAppearance_AppCompat_Inverse = 2131296315;
+			// aapt resource value: 0x7f0a0026
+			public const int Base_TextAppearance_AppCompat_Inverse = 2131361830;
 			
-			// aapt resource value: 0x7f09006f
-			public const int Base_TextAppearance_AppCompat_Large = 2131296367;
+			// aapt resource value: 0x7f0a005a
+			public const int Base_TextAppearance_AppCompat_Large = 2131361882;
 			
-			// aapt resource value: 0x7f09003c
-			public const int Base_TextAppearance_AppCompat_Large_Inverse = 2131296316;
+			// aapt resource value: 0x7f0a0027
+			public const int Base_TextAppearance_AppCompat_Large_Inverse = 2131361831;
 			
-			// aapt resource value: 0x7f090070
-			public const int Base_TextAppearance_AppCompat_Light_Widget_PopupMenu_Large = 2131296368;
+			// aapt resource value: 0x7f0a005b
+			public const int Base_TextAppearance_AppCompat_Light_Widget_PopupMenu_Large = 2131361883;
 			
-			// aapt resource value: 0x7f090071
-			public const int Base_TextAppearance_AppCompat_Light_Widget_PopupMenu_Small = 2131296369;
+			// aapt resource value: 0x7f0a005c
+			public const int Base_TextAppearance_AppCompat_Light_Widget_PopupMenu_Small = 2131361884;
 			
-			// aapt resource value: 0x7f090072
-			public const int Base_TextAppearance_AppCompat_Medium = 2131296370;
+			// aapt resource value: 0x7f0a005d
+			public const int Base_TextAppearance_AppCompat_Medium = 2131361885;
 			
-			// aapt resource value: 0x7f09003d
-			public const int Base_TextAppearance_AppCompat_Medium_Inverse = 2131296317;
+			// aapt resource value: 0x7f0a0028
+			public const int Base_TextAppearance_AppCompat_Medium_Inverse = 2131361832;
 			
-			// aapt resource value: 0x7f090073
-			public const int Base_TextAppearance_AppCompat_Menu = 2131296371;
+			// aapt resource value: 0x7f0a005e
+			public const int Base_TextAppearance_AppCompat_Menu = 2131361886;
 			
-			// aapt resource value: 0x7f0900c0
-			public const int Base_TextAppearance_AppCompat_SearchResult = 2131296448;
+			// aapt resource value: 0x7f0a00ab
+			public const int Base_TextAppearance_AppCompat_SearchResult = 2131361963;
 			
-			// aapt resource value: 0x7f090074
-			public const int Base_TextAppearance_AppCompat_SearchResult_Subtitle = 2131296372;
+			// aapt resource value: 0x7f0a005f
+			public const int Base_TextAppearance_AppCompat_SearchResult_Subtitle = 2131361887;
 			
-			// aapt resource value: 0x7f090075
-			public const int Base_TextAppearance_AppCompat_SearchResult_Title = 2131296373;
+			// aapt resource value: 0x7f0a0060
+			public const int Base_TextAppearance_AppCompat_SearchResult_Title = 2131361888;
 			
-			// aapt resource value: 0x7f090076
-			public const int Base_TextAppearance_AppCompat_Small = 2131296374;
+			// aapt resource value: 0x7f0a0061
+			public const int Base_TextAppearance_AppCompat_Small = 2131361889;
 			
-			// aapt resource value: 0x7f09003e
-			public const int Base_TextAppearance_AppCompat_Small_Inverse = 2131296318;
+			// aapt resource value: 0x7f0a0029
+			public const int Base_TextAppearance_AppCompat_Small_Inverse = 2131361833;
 			
-			// aapt resource value: 0x7f090077
-			public const int Base_TextAppearance_AppCompat_Subhead = 2131296375;
+			// aapt resource value: 0x7f0a0062
+			public const int Base_TextAppearance_AppCompat_Subhead = 2131361890;
 			
-			// aapt resource value: 0x7f09003f
-			public const int Base_TextAppearance_AppCompat_Subhead_Inverse = 2131296319;
+			// aapt resource value: 0x7f0a002a
+			public const int Base_TextAppearance_AppCompat_Subhead_Inverse = 2131361834;
 			
-			// aapt resource value: 0x7f090078
-			public const int Base_TextAppearance_AppCompat_Title = 2131296376;
+			// aapt resource value: 0x7f0a0063
+			public const int Base_TextAppearance_AppCompat_Title = 2131361891;
 			
-			// aapt resource value: 0x7f090040
-			public const int Base_TextAppearance_AppCompat_Title_Inverse = 2131296320;
+			// aapt resource value: 0x7f0a002b
+			public const int Base_TextAppearance_AppCompat_Title_Inverse = 2131361835;
 			
-			// aapt resource value: 0x7f0900af
-			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Menu = 2131296431;
+			// aapt resource value: 0x7f0a009a
+			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Menu = 2131361946;
 			
-			// aapt resource value: 0x7f090079
-			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Subtitle = 2131296377;
+			// aapt resource value: 0x7f0a0064
+			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Subtitle = 2131361892;
 			
-			// aapt resource value: 0x7f09007a
-			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Subtitle_Inverse = 2131296378;
+			// aapt resource value: 0x7f0a0065
+			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Subtitle_Inverse = 2131361893;
 			
-			// aapt resource value: 0x7f09007b
-			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Title = 2131296379;
+			// aapt resource value: 0x7f0a0066
+			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Title = 2131361894;
 			
-			// aapt resource value: 0x7f09007c
-			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Title_Inverse = 2131296380;
+			// aapt resource value: 0x7f0a0067
+			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Title_Inverse = 2131361895;
 			
-			// aapt resource value: 0x7f09007d
-			public const int Base_TextAppearance_AppCompat_Widget_ActionMode_Subtitle = 2131296381;
+			// aapt resource value: 0x7f0a0068
+			public const int Base_TextAppearance_AppCompat_Widget_ActionMode_Subtitle = 2131361896;
 			
-			// aapt resource value: 0x7f09007e
-			public const int Base_TextAppearance_AppCompat_Widget_ActionMode_Title = 2131296382;
+			// aapt resource value: 0x7f0a0069
+			public const int Base_TextAppearance_AppCompat_Widget_ActionMode_Title = 2131361897;
 			
-			// aapt resource value: 0x7f09007f
-			public const int Base_TextAppearance_AppCompat_Widget_Button = 2131296383;
+			// aapt resource value: 0x7f0a006a
+			public const int Base_TextAppearance_AppCompat_Widget_Button = 2131361898;
 			
-			// aapt resource value: 0x7f0900b0
-			public const int Base_TextAppearance_AppCompat_Widget_Button_Inverse = 2131296432;
+			// aapt resource value: 0x7f0a009b
+			public const int Base_TextAppearance_AppCompat_Widget_Button_Inverse = 2131361947;
 			
-			// aapt resource value: 0x7f0900c1
-			public const int Base_TextAppearance_AppCompat_Widget_DropDownItem = 2131296449;
+			// aapt resource value: 0x7f0a00ac
+			public const int Base_TextAppearance_AppCompat_Widget_DropDownItem = 2131361964;
 			
-			// aapt resource value: 0x7f090080
-			public const int Base_TextAppearance_AppCompat_Widget_PopupMenu_Large = 2131296384;
+			// aapt resource value: 0x7f0a006b
+			public const int Base_TextAppearance_AppCompat_Widget_PopupMenu_Large = 2131361899;
 			
-			// aapt resource value: 0x7f090081
-			public const int Base_TextAppearance_AppCompat_Widget_PopupMenu_Small = 2131296385;
+			// aapt resource value: 0x7f0a006c
+			public const int Base_TextAppearance_AppCompat_Widget_PopupMenu_Small = 2131361900;
 			
-			// aapt resource value: 0x7f090082
-			public const int Base_TextAppearance_AppCompat_Widget_Switch = 2131296386;
+			// aapt resource value: 0x7f0a006d
+			public const int Base_TextAppearance_AppCompat_Widget_Switch = 2131361901;
 			
-			// aapt resource value: 0x7f090083
-			public const int Base_TextAppearance_AppCompat_Widget_TextView_SpinnerItem = 2131296387;
+			// aapt resource value: 0x7f0a006e
+			public const int Base_TextAppearance_AppCompat_Widget_TextView_SpinnerItem = 2131361902;
 			
-			// aapt resource value: 0x7f0900c2
-			public const int Base_TextAppearance_Widget_AppCompat_ExpandedMenu_Item = 2131296450;
+			// aapt resource value: 0x7f0a00ad
+			public const int Base_TextAppearance_Widget_AppCompat_ExpandedMenu_Item = 2131361965;
 			
-			// aapt resource value: 0x7f090084
-			public const int Base_TextAppearance_Widget_AppCompat_Toolbar_Subtitle = 2131296388;
+			// aapt resource value: 0x7f0a006f
+			public const int Base_TextAppearance_Widget_AppCompat_Toolbar_Subtitle = 2131361903;
 			
-			// aapt resource value: 0x7f090085
-			public const int Base_TextAppearance_Widget_AppCompat_Toolbar_Title = 2131296389;
+			// aapt resource value: 0x7f0a0070
+			public const int Base_TextAppearance_Widget_AppCompat_Toolbar_Title = 2131361904;
 			
-			// aapt resource value: 0x7f090086
-			public const int Base_Theme_AppCompat = 2131296390;
+			// aapt resource value: 0x7f0a0071
+			public const int Base_Theme_AppCompat = 2131361905;
 			
-			// aapt resource value: 0x7f0900c3
-			public const int Base_Theme_AppCompat_CompactMenu = 2131296451;
+			// aapt resource value: 0x7f0a00ae
+			public const int Base_Theme_AppCompat_CompactMenu = 2131361966;
 			
-			// aapt resource value: 0x7f090041
-			public const int Base_Theme_AppCompat_Dialog = 2131296321;
+			// aapt resource value: 0x7f0a002c
+			public const int Base_Theme_AppCompat_Dialog = 2131361836;
 			
-			// aapt resource value: 0x7f0900c4
-			public const int Base_Theme_AppCompat_Dialog_Alert = 2131296452;
+			// aapt resource value: 0x7f0a00af
+			public const int Base_Theme_AppCompat_Dialog_Alert = 2131361967;
 			
-			// aapt resource value: 0x7f0900c5
-			public const int Base_Theme_AppCompat_Dialog_FixedSize = 2131296453;
+			// aapt resource value: 0x7f0a00b0
+			public const int Base_Theme_AppCompat_Dialog_FixedSize = 2131361968;
 			
-			// aapt resource value: 0x7f0900c6
-			public const int Base_Theme_AppCompat_Dialog_MinWidth = 2131296454;
+			// aapt resource value: 0x7f0a00b1
+			public const int Base_Theme_AppCompat_Dialog_MinWidth = 2131361969;
 			
-			// aapt resource value: 0x7f090031
-			public const int Base_Theme_AppCompat_DialogWhenLarge = 2131296305;
+			// aapt resource value: 0x7f0a001c
+			public const int Base_Theme_AppCompat_DialogWhenLarge = 2131361820;
 			
-			// aapt resource value: 0x7f090087
-			public const int Base_Theme_AppCompat_Light = 2131296391;
+			// aapt resource value: 0x7f0a0072
+			public const int Base_Theme_AppCompat_Light = 2131361906;
 			
-			// aapt resource value: 0x7f0900c7
-			public const int Base_Theme_AppCompat_Light_DarkActionBar = 2131296455;
+			// aapt resource value: 0x7f0a00b2
+			public const int Base_Theme_AppCompat_Light_DarkActionBar = 2131361970;
 			
-			// aapt resource value: 0x7f090042
-			public const int Base_Theme_AppCompat_Light_Dialog = 2131296322;
+			// aapt resource value: 0x7f0a002d
+			public const int Base_Theme_AppCompat_Light_Dialog = 2131361837;
 			
-			// aapt resource value: 0x7f0900c8
-			public const int Base_Theme_AppCompat_Light_Dialog_Alert = 2131296456;
+			// aapt resource value: 0x7f0a00b3
+			public const int Base_Theme_AppCompat_Light_Dialog_Alert = 2131361971;
 			
-			// aapt resource value: 0x7f0900c9
-			public const int Base_Theme_AppCompat_Light_Dialog_FixedSize = 2131296457;
+			// aapt resource value: 0x7f0a00b4
+			public const int Base_Theme_AppCompat_Light_Dialog_FixedSize = 2131361972;
 			
-			// aapt resource value: 0x7f0900ca
-			public const int Base_Theme_AppCompat_Light_Dialog_MinWidth = 2131296458;
+			// aapt resource value: 0x7f0a00b5
+			public const int Base_Theme_AppCompat_Light_Dialog_MinWidth = 2131361973;
 			
-			// aapt resource value: 0x7f090032
-			public const int Base_Theme_AppCompat_Light_DialogWhenLarge = 2131296306;
+			// aapt resource value: 0x7f0a001d
+			public const int Base_Theme_AppCompat_Light_DialogWhenLarge = 2131361821;
 			
-			// aapt resource value: 0x7f0900cb
-			public const int Base_ThemeOverlay_AppCompat = 2131296459;
+			// aapt resource value: 0x7f0a00b6
+			public const int Base_ThemeOverlay_AppCompat = 2131361974;
 			
-			// aapt resource value: 0x7f0900cc
-			public const int Base_ThemeOverlay_AppCompat_ActionBar = 2131296460;
+			// aapt resource value: 0x7f0a00b7
+			public const int Base_ThemeOverlay_AppCompat_ActionBar = 2131361975;
 			
-			// aapt resource value: 0x7f0900cd
-			public const int Base_ThemeOverlay_AppCompat_Dark = 2131296461;
+			// aapt resource value: 0x7f0a00b8
+			public const int Base_ThemeOverlay_AppCompat_Dark = 2131361976;
 			
-			// aapt resource value: 0x7f0900ce
-			public const int Base_ThemeOverlay_AppCompat_Dark_ActionBar = 2131296462;
+			// aapt resource value: 0x7f0a00b9
+			public const int Base_ThemeOverlay_AppCompat_Dark_ActionBar = 2131361977;
 			
-			// aapt resource value: 0x7f0900cf
-			public const int Base_ThemeOverlay_AppCompat_Light = 2131296463;
+			// aapt resource value: 0x7f0a00ba
+			public const int Base_ThemeOverlay_AppCompat_Light = 2131361978;
 			
-			// aapt resource value: 0x7f090043
-			public const int Base_V11_Theme_AppCompat_Dialog = 2131296323;
+			// aapt resource value: 0x7f0a002e
+			public const int Base_V11_Theme_AppCompat_Dialog = 2131361838;
 			
-			// aapt resource value: 0x7f090044
-			public const int Base_V11_Theme_AppCompat_Light_Dialog = 2131296324;
+			// aapt resource value: 0x7f0a002f
+			public const int Base_V11_Theme_AppCompat_Light_Dialog = 2131361839;
 			
-			// aapt resource value: 0x7f09004c
-			public const int Base_V12_Widget_AppCompat_AutoCompleteTextView = 2131296332;
+			// aapt resource value: 0x7f0a0037
+			public const int Base_V12_Widget_AppCompat_AutoCompleteTextView = 2131361847;
 			
-			// aapt resource value: 0x7f09004d
-			public const int Base_V12_Widget_AppCompat_EditText = 2131296333;
+			// aapt resource value: 0x7f0a0038
+			public const int Base_V12_Widget_AppCompat_EditText = 2131361848;
 			
-			// aapt resource value: 0x7f090088
-			public const int Base_V21_Theme_AppCompat = 2131296392;
+			// aapt resource value: 0x7f0a0073
+			public const int Base_V21_Theme_AppCompat = 2131361907;
 			
-			// aapt resource value: 0x7f090089
-			public const int Base_V21_Theme_AppCompat_Dialog = 2131296393;
+			// aapt resource value: 0x7f0a0074
+			public const int Base_V21_Theme_AppCompat_Dialog = 2131361908;
 			
-			// aapt resource value: 0x7f09008a
-			public const int Base_V21_Theme_AppCompat_Light = 2131296394;
+			// aapt resource value: 0x7f0a0075
+			public const int Base_V21_Theme_AppCompat_Light = 2131361909;
 			
-			// aapt resource value: 0x7f09008b
-			public const int Base_V21_Theme_AppCompat_Light_Dialog = 2131296395;
+			// aapt resource value: 0x7f0a0076
+			public const int Base_V21_Theme_AppCompat_Light_Dialog = 2131361910;
 			
-			// aapt resource value: 0x7f0900ad
-			public const int Base_V22_Theme_AppCompat = 2131296429;
+			// aapt resource value: 0x7f0a0098
+			public const int Base_V22_Theme_AppCompat = 2131361944;
 			
-			// aapt resource value: 0x7f0900ae
-			public const int Base_V22_Theme_AppCompat_Light = 2131296430;
+			// aapt resource value: 0x7f0a0099
+			public const int Base_V22_Theme_AppCompat_Light = 2131361945;
 			
-			// aapt resource value: 0x7f0900b1
-			public const int Base_V23_Theme_AppCompat = 2131296433;
+			// aapt resource value: 0x7f0a009c
+			public const int Base_V23_Theme_AppCompat = 2131361948;
 			
-			// aapt resource value: 0x7f0900b2
-			public const int Base_V23_Theme_AppCompat_Light = 2131296434;
+			// aapt resource value: 0x7f0a009d
+			public const int Base_V23_Theme_AppCompat_Light = 2131361949;
 			
-			// aapt resource value: 0x7f0900d0
-			public const int Base_V7_Theme_AppCompat = 2131296464;
+			// aapt resource value: 0x7f0a00bb
+			public const int Base_V7_Theme_AppCompat = 2131361979;
 			
-			// aapt resource value: 0x7f0900d1
-			public const int Base_V7_Theme_AppCompat_Dialog = 2131296465;
+			// aapt resource value: 0x7f0a00bc
+			public const int Base_V7_Theme_AppCompat_Dialog = 2131361980;
 			
-			// aapt resource value: 0x7f0900d2
-			public const int Base_V7_Theme_AppCompat_Light = 2131296466;
+			// aapt resource value: 0x7f0a00bd
+			public const int Base_V7_Theme_AppCompat_Light = 2131361981;
 			
-			// aapt resource value: 0x7f0900d3
-			public const int Base_V7_Theme_AppCompat_Light_Dialog = 2131296467;
+			// aapt resource value: 0x7f0a00be
+			public const int Base_V7_Theme_AppCompat_Light_Dialog = 2131361982;
 			
-			// aapt resource value: 0x7f0900d4
-			public const int Base_V7_Widget_AppCompat_AutoCompleteTextView = 2131296468;
+			// aapt resource value: 0x7f0a00bf
+			public const int Base_V7_Widget_AppCompat_AutoCompleteTextView = 2131361983;
 			
-			// aapt resource value: 0x7f0900d5
-			public const int Base_V7_Widget_AppCompat_EditText = 2131296469;
+			// aapt resource value: 0x7f0a00c0
+			public const int Base_V7_Widget_AppCompat_EditText = 2131361984;
 			
-			// aapt resource value: 0x7f0900d6
-			public const int Base_Widget_AppCompat_ActionBar = 2131296470;
+			// aapt resource value: 0x7f0a00c1
+			public const int Base_Widget_AppCompat_ActionBar = 2131361985;
 			
-			// aapt resource value: 0x7f0900d7
-			public const int Base_Widget_AppCompat_ActionBar_Solid = 2131296471;
+			// aapt resource value: 0x7f0a00c2
+			public const int Base_Widget_AppCompat_ActionBar_Solid = 2131361986;
 			
-			// aapt resource value: 0x7f0900d8
-			public const int Base_Widget_AppCompat_ActionBar_TabBar = 2131296472;
+			// aapt resource value: 0x7f0a00c3
+			public const int Base_Widget_AppCompat_ActionBar_TabBar = 2131361987;
 			
-			// aapt resource value: 0x7f09008c
-			public const int Base_Widget_AppCompat_ActionBar_TabText = 2131296396;
+			// aapt resource value: 0x7f0a0077
+			public const int Base_Widget_AppCompat_ActionBar_TabText = 2131361911;
 			
-			// aapt resource value: 0x7f09008d
-			public const int Base_Widget_AppCompat_ActionBar_TabView = 2131296397;
+			// aapt resource value: 0x7f0a0078
+			public const int Base_Widget_AppCompat_ActionBar_TabView = 2131361912;
 			
-			// aapt resource value: 0x7f09008e
-			public const int Base_Widget_AppCompat_ActionButton = 2131296398;
+			// aapt resource value: 0x7f0a0079
+			public const int Base_Widget_AppCompat_ActionButton = 2131361913;
 			
-			// aapt resource value: 0x7f09008f
-			public const int Base_Widget_AppCompat_ActionButton_CloseMode = 2131296399;
+			// aapt resource value: 0x7f0a007a
+			public const int Base_Widget_AppCompat_ActionButton_CloseMode = 2131361914;
 			
-			// aapt resource value: 0x7f090090
-			public const int Base_Widget_AppCompat_ActionButton_Overflow = 2131296400;
+			// aapt resource value: 0x7f0a007b
+			public const int Base_Widget_AppCompat_ActionButton_Overflow = 2131361915;
 			
-			// aapt resource value: 0x7f0900d9
-			public const int Base_Widget_AppCompat_ActionMode = 2131296473;
+			// aapt resource value: 0x7f0a00c4
+			public const int Base_Widget_AppCompat_ActionMode = 2131361988;
 			
-			// aapt resource value: 0x7f0900da
-			public const int Base_Widget_AppCompat_ActivityChooserView = 2131296474;
+			// aapt resource value: 0x7f0a00c5
+			public const int Base_Widget_AppCompat_ActivityChooserView = 2131361989;
 			
-			// aapt resource value: 0x7f09004e
-			public const int Base_Widget_AppCompat_AutoCompleteTextView = 2131296334;
+			// aapt resource value: 0x7f0a0039
+			public const int Base_Widget_AppCompat_AutoCompleteTextView = 2131361849;
 			
-			// aapt resource value: 0x7f090091
-			public const int Base_Widget_AppCompat_Button = 2131296401;
+			// aapt resource value: 0x7f0a007c
+			public const int Base_Widget_AppCompat_Button = 2131361916;
 			
-			// aapt resource value: 0x7f090092
-			public const int Base_Widget_AppCompat_Button_Borderless = 2131296402;
+			// aapt resource value: 0x7f0a007d
+			public const int Base_Widget_AppCompat_Button_Borderless = 2131361917;
 			
-			// aapt resource value: 0x7f090093
-			public const int Base_Widget_AppCompat_Button_Borderless_Colored = 2131296403;
+			// aapt resource value: 0x7f0a007e
+			public const int Base_Widget_AppCompat_Button_Borderless_Colored = 2131361918;
 			
-			// aapt resource value: 0x7f0900db
-			public const int Base_Widget_AppCompat_Button_ButtonBar_AlertDialog = 2131296475;
+			// aapt resource value: 0x7f0a00c6
+			public const int Base_Widget_AppCompat_Button_ButtonBar_AlertDialog = 2131361990;
 			
-			// aapt resource value: 0x7f0900b3
-			public const int Base_Widget_AppCompat_Button_Colored = 2131296435;
+			// aapt resource value: 0x7f0a009e
+			public const int Base_Widget_AppCompat_Button_Colored = 2131361950;
 			
-			// aapt resource value: 0x7f090094
-			public const int Base_Widget_AppCompat_Button_Small = 2131296404;
+			// aapt resource value: 0x7f0a007f
+			public const int Base_Widget_AppCompat_Button_Small = 2131361919;
 			
-			// aapt resource value: 0x7f090095
-			public const int Base_Widget_AppCompat_ButtonBar = 2131296405;
+			// aapt resource value: 0x7f0a0080
+			public const int Base_Widget_AppCompat_ButtonBar = 2131361920;
 			
-			// aapt resource value: 0x7f0900dc
-			public const int Base_Widget_AppCompat_ButtonBar_AlertDialog = 2131296476;
+			// aapt resource value: 0x7f0a00c7
+			public const int Base_Widget_AppCompat_ButtonBar_AlertDialog = 2131361991;
 			
-			// aapt resource value: 0x7f090096
-			public const int Base_Widget_AppCompat_CompoundButton_CheckBox = 2131296406;
+			// aapt resource value: 0x7f0a0081
+			public const int Base_Widget_AppCompat_CompoundButton_CheckBox = 2131361921;
 			
-			// aapt resource value: 0x7f090097
-			public const int Base_Widget_AppCompat_CompoundButton_RadioButton = 2131296407;
+			// aapt resource value: 0x7f0a0082
+			public const int Base_Widget_AppCompat_CompoundButton_RadioButton = 2131361922;
 			
-			// aapt resource value: 0x7f0900dd
-			public const int Base_Widget_AppCompat_CompoundButton_Switch = 2131296477;
+			// aapt resource value: 0x7f0a00c8
+			public const int Base_Widget_AppCompat_CompoundButton_Switch = 2131361992;
 			
-			// aapt resource value: 0x7f090030
-			public const int Base_Widget_AppCompat_DrawerArrowToggle = 2131296304;
+			// aapt resource value: 0x7f0a001b
+			public const int Base_Widget_AppCompat_DrawerArrowToggle = 2131361819;
 			
-			// aapt resource value: 0x7f0900de
-			public const int Base_Widget_AppCompat_DrawerArrowToggle_Common = 2131296478;
+			// aapt resource value: 0x7f0a00c9
+			public const int Base_Widget_AppCompat_DrawerArrowToggle_Common = 2131361993;
 			
-			// aapt resource value: 0x7f090098
-			public const int Base_Widget_AppCompat_DropDownItem_Spinner = 2131296408;
+			// aapt resource value: 0x7f0a0083
+			public const int Base_Widget_AppCompat_DropDownItem_Spinner = 2131361923;
 			
-			// aapt resource value: 0x7f09004f
-			public const int Base_Widget_AppCompat_EditText = 2131296335;
+			// aapt resource value: 0x7f0a003a
+			public const int Base_Widget_AppCompat_EditText = 2131361850;
 			
-			// aapt resource value: 0x7f090099
-			public const int Base_Widget_AppCompat_ImageButton = 2131296409;
+			// aapt resource value: 0x7f0a0084
+			public const int Base_Widget_AppCompat_ImageButton = 2131361924;
 			
-			// aapt resource value: 0x7f0900df
-			public const int Base_Widget_AppCompat_Light_ActionBar = 2131296479;
+			// aapt resource value: 0x7f0a00ca
+			public const int Base_Widget_AppCompat_Light_ActionBar = 2131361994;
 			
-			// aapt resource value: 0x7f0900e0
-			public const int Base_Widget_AppCompat_Light_ActionBar_Solid = 2131296480;
+			// aapt resource value: 0x7f0a00cb
+			public const int Base_Widget_AppCompat_Light_ActionBar_Solid = 2131361995;
 			
-			// aapt resource value: 0x7f0900e1
-			public const int Base_Widget_AppCompat_Light_ActionBar_TabBar = 2131296481;
+			// aapt resource value: 0x7f0a00cc
+			public const int Base_Widget_AppCompat_Light_ActionBar_TabBar = 2131361996;
 			
-			// aapt resource value: 0x7f09009a
-			public const int Base_Widget_AppCompat_Light_ActionBar_TabText = 2131296410;
+			// aapt resource value: 0x7f0a0085
+			public const int Base_Widget_AppCompat_Light_ActionBar_TabText = 2131361925;
 			
-			// aapt resource value: 0x7f09009b
-			public const int Base_Widget_AppCompat_Light_ActionBar_TabText_Inverse = 2131296411;
+			// aapt resource value: 0x7f0a0086
+			public const int Base_Widget_AppCompat_Light_ActionBar_TabText_Inverse = 2131361926;
 			
-			// aapt resource value: 0x7f09009c
-			public const int Base_Widget_AppCompat_Light_ActionBar_TabView = 2131296412;
+			// aapt resource value: 0x7f0a0087
+			public const int Base_Widget_AppCompat_Light_ActionBar_TabView = 2131361927;
 			
-			// aapt resource value: 0x7f09009d
-			public const int Base_Widget_AppCompat_Light_PopupMenu = 2131296413;
+			// aapt resource value: 0x7f0a0088
+			public const int Base_Widget_AppCompat_Light_PopupMenu = 2131361928;
 			
-			// aapt resource value: 0x7f09009e
-			public const int Base_Widget_AppCompat_Light_PopupMenu_Overflow = 2131296414;
+			// aapt resource value: 0x7f0a0089
+			public const int Base_Widget_AppCompat_Light_PopupMenu_Overflow = 2131361929;
 			
-			// aapt resource value: 0x7f09009f
-			public const int Base_Widget_AppCompat_ListPopupWindow = 2131296415;
+			// aapt resource value: 0x7f0a008a
+			public const int Base_Widget_AppCompat_ListPopupWindow = 2131361930;
 			
-			// aapt resource value: 0x7f0900a0
-			public const int Base_Widget_AppCompat_ListView = 2131296416;
+			// aapt resource value: 0x7f0a008b
+			public const int Base_Widget_AppCompat_ListView = 2131361931;
 			
-			// aapt resource value: 0x7f0900a1
-			public const int Base_Widget_AppCompat_ListView_DropDown = 2131296417;
+			// aapt resource value: 0x7f0a008c
+			public const int Base_Widget_AppCompat_ListView_DropDown = 2131361932;
 			
-			// aapt resource value: 0x7f0900a2
-			public const int Base_Widget_AppCompat_ListView_Menu = 2131296418;
+			// aapt resource value: 0x7f0a008d
+			public const int Base_Widget_AppCompat_ListView_Menu = 2131361933;
 			
-			// aapt resource value: 0x7f0900a3
-			public const int Base_Widget_AppCompat_PopupMenu = 2131296419;
+			// aapt resource value: 0x7f0a008e
+			public const int Base_Widget_AppCompat_PopupMenu = 2131361934;
 			
-			// aapt resource value: 0x7f0900a4
-			public const int Base_Widget_AppCompat_PopupMenu_Overflow = 2131296420;
+			// aapt resource value: 0x7f0a008f
+			public const int Base_Widget_AppCompat_PopupMenu_Overflow = 2131361935;
 			
-			// aapt resource value: 0x7f0900e2
-			public const int Base_Widget_AppCompat_PopupWindow = 2131296482;
+			// aapt resource value: 0x7f0a00cd
+			public const int Base_Widget_AppCompat_PopupWindow = 2131361997;
 			
-			// aapt resource value: 0x7f090045
-			public const int Base_Widget_AppCompat_ProgressBar = 2131296325;
+			// aapt resource value: 0x7f0a0030
+			public const int Base_Widget_AppCompat_ProgressBar = 2131361840;
 			
-			// aapt resource value: 0x7f090046
-			public const int Base_Widget_AppCompat_ProgressBar_Horizontal = 2131296326;
+			// aapt resource value: 0x7f0a0031
+			public const int Base_Widget_AppCompat_ProgressBar_Horizontal = 2131361841;
 			
-			// aapt resource value: 0x7f0900a5
-			public const int Base_Widget_AppCompat_RatingBar = 2131296421;
+			// aapt resource value: 0x7f0a0090
+			public const int Base_Widget_AppCompat_RatingBar = 2131361936;
 			
-			// aapt resource value: 0x7f0900b4
-			public const int Base_Widget_AppCompat_RatingBar_Indicator = 2131296436;
+			// aapt resource value: 0x7f0a009f
+			public const int Base_Widget_AppCompat_RatingBar_Indicator = 2131361951;
 			
-			// aapt resource value: 0x7f0900b5
-			public const int Base_Widget_AppCompat_RatingBar_Small = 2131296437;
+			// aapt resource value: 0x7f0a00a0
+			public const int Base_Widget_AppCompat_RatingBar_Small = 2131361952;
 			
-			// aapt resource value: 0x7f0900e3
-			public const int Base_Widget_AppCompat_SearchView = 2131296483;
+			// aapt resource value: 0x7f0a00ce
+			public const int Base_Widget_AppCompat_SearchView = 2131361998;
 			
-			// aapt resource value: 0x7f0900e4
-			public const int Base_Widget_AppCompat_SearchView_ActionBar = 2131296484;
+			// aapt resource value: 0x7f0a00cf
+			public const int Base_Widget_AppCompat_SearchView_ActionBar = 2131361999;
 			
-			// aapt resource value: 0x7f0900a6
-			public const int Base_Widget_AppCompat_SeekBar = 2131296422;
+			// aapt resource value: 0x7f0a0091
+			public const int Base_Widget_AppCompat_SeekBar = 2131361937;
 			
-			// aapt resource value: 0x7f0900a7
-			public const int Base_Widget_AppCompat_Spinner = 2131296423;
+			// aapt resource value: 0x7f0a0092
+			public const int Base_Widget_AppCompat_Spinner = 2131361938;
 			
-			// aapt resource value: 0x7f090033
-			public const int Base_Widget_AppCompat_Spinner_Underlined = 2131296307;
+			// aapt resource value: 0x7f0a001e
+			public const int Base_Widget_AppCompat_Spinner_Underlined = 2131361822;
 			
-			// aapt resource value: 0x7f0900a8
-			public const int Base_Widget_AppCompat_TextView_SpinnerItem = 2131296424;
+			// aapt resource value: 0x7f0a0093
+			public const int Base_Widget_AppCompat_TextView_SpinnerItem = 2131361939;
 			
-			// aapt resource value: 0x7f0900e5
-			public const int Base_Widget_AppCompat_Toolbar = 2131296485;
+			// aapt resource value: 0x7f0a00d0
+			public const int Base_Widget_AppCompat_Toolbar = 2131362000;
 			
-			// aapt resource value: 0x7f0900a9
-			public const int Base_Widget_AppCompat_Toolbar_Button_Navigation = 2131296425;
+			// aapt resource value: 0x7f0a0094
+			public const int Base_Widget_AppCompat_Toolbar_Button_Navigation = 2131361940;
 			
-			// aapt resource value: 0x7f090019
-			public const int Base_Widget_Design_TabLayout = 2131296281;
+			// aapt resource value: 0x7f0a015b
+			public const int Base_Widget_Design_TabLayout = 2131362139;
 			
-			// aapt resource value: 0x7f09016e
-			public const int CardView = 2131296622;
+			// aapt resource value: 0x7f0a0017
+			public const int CardView = 2131361815;
 			
-			// aapt resource value: 0x7f090170
-			public const int CardView_Dark = 2131296624;
+			// aapt resource value: 0x7f0a0019
+			public const int CardView_Dark = 2131361817;
 			
-			// aapt resource value: 0x7f090171
-			public const int CardView_Light = 2131296625;
+			// aapt resource value: 0x7f0a001a
+			public const int CardView_Light = 2131361818;
 			
-			// aapt resource value: 0x7f090047
-			public const int Platform_AppCompat = 2131296327;
+			// aapt resource value: 0x7f0a0032
+			public const int Platform_AppCompat = 2131361842;
 			
-			// aapt resource value: 0x7f090048
-			public const int Platform_AppCompat_Light = 2131296328;
+			// aapt resource value: 0x7f0a0033
+			public const int Platform_AppCompat_Light = 2131361843;
 			
-			// aapt resource value: 0x7f0900aa
-			public const int Platform_ThemeOverlay_AppCompat = 2131296426;
+			// aapt resource value: 0x7f0a0095
+			public const int Platform_ThemeOverlay_AppCompat = 2131361941;
 			
-			// aapt resource value: 0x7f0900ab
-			public const int Platform_ThemeOverlay_AppCompat_Dark = 2131296427;
+			// aapt resource value: 0x7f0a0096
+			public const int Platform_ThemeOverlay_AppCompat_Dark = 2131361942;
 			
-			// aapt resource value: 0x7f0900ac
-			public const int Platform_ThemeOverlay_AppCompat_Light = 2131296428;
+			// aapt resource value: 0x7f0a0097
+			public const int Platform_ThemeOverlay_AppCompat_Light = 2131361943;
 			
-			// aapt resource value: 0x7f090049
-			public const int Platform_V11_AppCompat = 2131296329;
+			// aapt resource value: 0x7f0a0034
+			public const int Platform_V11_AppCompat = 2131361844;
 			
-			// aapt resource value: 0x7f09004a
-			public const int Platform_V11_AppCompat_Light = 2131296330;
+			// aapt resource value: 0x7f0a0035
+			public const int Platform_V11_AppCompat_Light = 2131361845;
 			
-			// aapt resource value: 0x7f090051
-			public const int Platform_V14_AppCompat = 2131296337;
+			// aapt resource value: 0x7f0a003c
+			public const int Platform_V14_AppCompat = 2131361852;
 			
-			// aapt resource value: 0x7f090052
-			public const int Platform_V14_AppCompat_Light = 2131296338;
+			// aapt resource value: 0x7f0a003d
+			public const int Platform_V14_AppCompat_Light = 2131361853;
 			
-			// aapt resource value: 0x7f09004b
-			public const int Platform_Widget_AppCompat_Spinner = 2131296331;
+			// aapt resource value: 0x7f0a0036
+			public const int Platform_Widget_AppCompat_Spinner = 2131361846;
 			
-			// aapt resource value: 0x7f090058
-			public const int RtlOverlay_DialogWindowTitle_AppCompat = 2131296344;
+			// aapt resource value: 0x7f0a0043
+			public const int RtlOverlay_DialogWindowTitle_AppCompat = 2131361859;
 			
-			// aapt resource value: 0x7f090059
-			public const int RtlOverlay_Widget_AppCompat_ActionBar_TitleItem = 2131296345;
+			// aapt resource value: 0x7f0a0044
+			public const int RtlOverlay_Widget_AppCompat_ActionBar_TitleItem = 2131361860;
 			
-			// aapt resource value: 0x7f09005a
-			public const int RtlOverlay_Widget_AppCompat_DialogTitle_Icon = 2131296346;
+			// aapt resource value: 0x7f0a0045
+			public const int RtlOverlay_Widget_AppCompat_DialogTitle_Icon = 2131361861;
 			
-			// aapt resource value: 0x7f09005b
-			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem = 2131296347;
+			// aapt resource value: 0x7f0a0046
+			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem = 2131361862;
 			
-			// aapt resource value: 0x7f09005c
-			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem_InternalGroup = 2131296348;
+			// aapt resource value: 0x7f0a0047
+			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem_InternalGroup = 2131361863;
 			
-			// aapt resource value: 0x7f09005d
-			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem_Text = 2131296349;
+			// aapt resource value: 0x7f0a0048
+			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem_Text = 2131361864;
 			
-			// aapt resource value: 0x7f09005e
-			public const int RtlOverlay_Widget_AppCompat_Search_DropDown = 2131296350;
+			// aapt resource value: 0x7f0a0049
+			public const int RtlOverlay_Widget_AppCompat_Search_DropDown = 2131361865;
 			
-			// aapt resource value: 0x7f09005f
-			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Icon1 = 2131296351;
+			// aapt resource value: 0x7f0a004a
+			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Icon1 = 2131361866;
 			
-			// aapt resource value: 0x7f090060
-			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Icon2 = 2131296352;
+			// aapt resource value: 0x7f0a004b
+			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Icon2 = 2131361867;
 			
-			// aapt resource value: 0x7f090061
-			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Query = 2131296353;
+			// aapt resource value: 0x7f0a004c
+			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Query = 2131361868;
 			
-			// aapt resource value: 0x7f090062
-			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Text = 2131296354;
+			// aapt resource value: 0x7f0a004d
+			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Text = 2131361869;
 			
-			// aapt resource value: 0x7f090063
-			public const int RtlOverlay_Widget_AppCompat_SearchView_MagIcon = 2131296355;
+			// aapt resource value: 0x7f0a004e
+			public const int RtlOverlay_Widget_AppCompat_SearchView_MagIcon = 2131361870;
 			
-			// aapt resource value: 0x7f090064
-			public const int RtlUnderlay_Widget_AppCompat_ActionButton = 2131296356;
+			// aapt resource value: 0x7f0a004f
+			public const int RtlUnderlay_Widget_AppCompat_ActionButton = 2131361871;
 			
-			// aapt resource value: 0x7f090065
-			public const int RtlUnderlay_Widget_AppCompat_ActionButton_Overflow = 2131296357;
+			// aapt resource value: 0x7f0a0050
+			public const int RtlUnderlay_Widget_AppCompat_ActionButton_Overflow = 2131361872;
 			
-			// aapt resource value: 0x7f0900e6
-			public const int TextAppearance_AppCompat = 2131296486;
+			// aapt resource value: 0x7f0a00d1
+			public const int TextAppearance_AppCompat = 2131362001;
 			
-			// aapt resource value: 0x7f0900e7
-			public const int TextAppearance_AppCompat_Body1 = 2131296487;
+			// aapt resource value: 0x7f0a00d2
+			public const int TextAppearance_AppCompat_Body1 = 2131362002;
 			
-			// aapt resource value: 0x7f0900e8
-			public const int TextAppearance_AppCompat_Body2 = 2131296488;
+			// aapt resource value: 0x7f0a00d3
+			public const int TextAppearance_AppCompat_Body2 = 2131362003;
 			
-			// aapt resource value: 0x7f0900e9
-			public const int TextAppearance_AppCompat_Button = 2131296489;
+			// aapt resource value: 0x7f0a00d4
+			public const int TextAppearance_AppCompat_Button = 2131362004;
 			
-			// aapt resource value: 0x7f0900ea
-			public const int TextAppearance_AppCompat_Caption = 2131296490;
+			// aapt resource value: 0x7f0a00d5
+			public const int TextAppearance_AppCompat_Caption = 2131362005;
 			
-			// aapt resource value: 0x7f0900eb
-			public const int TextAppearance_AppCompat_Display1 = 2131296491;
+			// aapt resource value: 0x7f0a00d6
+			public const int TextAppearance_AppCompat_Display1 = 2131362006;
 			
-			// aapt resource value: 0x7f0900ec
-			public const int TextAppearance_AppCompat_Display2 = 2131296492;
+			// aapt resource value: 0x7f0a00d7
+			public const int TextAppearance_AppCompat_Display2 = 2131362007;
 			
-			// aapt resource value: 0x7f0900ed
-			public const int TextAppearance_AppCompat_Display3 = 2131296493;
+			// aapt resource value: 0x7f0a00d8
+			public const int TextAppearance_AppCompat_Display3 = 2131362008;
 			
-			// aapt resource value: 0x7f0900ee
-			public const int TextAppearance_AppCompat_Display4 = 2131296494;
+			// aapt resource value: 0x7f0a00d9
+			public const int TextAppearance_AppCompat_Display4 = 2131362009;
 			
-			// aapt resource value: 0x7f0900ef
-			public const int TextAppearance_AppCompat_Headline = 2131296495;
+			// aapt resource value: 0x7f0a00da
+			public const int TextAppearance_AppCompat_Headline = 2131362010;
 			
-			// aapt resource value: 0x7f0900f0
-			public const int TextAppearance_AppCompat_Inverse = 2131296496;
+			// aapt resource value: 0x7f0a00db
+			public const int TextAppearance_AppCompat_Inverse = 2131362011;
 			
-			// aapt resource value: 0x7f0900f1
-			public const int TextAppearance_AppCompat_Large = 2131296497;
+			// aapt resource value: 0x7f0a00dc
+			public const int TextAppearance_AppCompat_Large = 2131362012;
 			
-			// aapt resource value: 0x7f0900f2
-			public const int TextAppearance_AppCompat_Large_Inverse = 2131296498;
+			// aapt resource value: 0x7f0a00dd
+			public const int TextAppearance_AppCompat_Large_Inverse = 2131362013;
 			
-			// aapt resource value: 0x7f0900f3
-			public const int TextAppearance_AppCompat_Light_SearchResult_Subtitle = 2131296499;
+			// aapt resource value: 0x7f0a00de
+			public const int TextAppearance_AppCompat_Light_SearchResult_Subtitle = 2131362014;
 			
-			// aapt resource value: 0x7f0900f4
-			public const int TextAppearance_AppCompat_Light_SearchResult_Title = 2131296500;
+			// aapt resource value: 0x7f0a00df
+			public const int TextAppearance_AppCompat_Light_SearchResult_Title = 2131362015;
 			
-			// aapt resource value: 0x7f0900f5
-			public const int TextAppearance_AppCompat_Light_Widget_PopupMenu_Large = 2131296501;
+			// aapt resource value: 0x7f0a00e0
+			public const int TextAppearance_AppCompat_Light_Widget_PopupMenu_Large = 2131362016;
 			
-			// aapt resource value: 0x7f0900f6
-			public const int TextAppearance_AppCompat_Light_Widget_PopupMenu_Small = 2131296502;
+			// aapt resource value: 0x7f0a00e1
+			public const int TextAppearance_AppCompat_Light_Widget_PopupMenu_Small = 2131362017;
 			
-			// aapt resource value: 0x7f0900f7
-			public const int TextAppearance_AppCompat_Medium = 2131296503;
+			// aapt resource value: 0x7f0a00e2
+			public const int TextAppearance_AppCompat_Medium = 2131362018;
 			
-			// aapt resource value: 0x7f0900f8
-			public const int TextAppearance_AppCompat_Medium_Inverse = 2131296504;
+			// aapt resource value: 0x7f0a00e3
+			public const int TextAppearance_AppCompat_Medium_Inverse = 2131362019;
 			
-			// aapt resource value: 0x7f0900f9
-			public const int TextAppearance_AppCompat_Menu = 2131296505;
+			// aapt resource value: 0x7f0a00e4
+			public const int TextAppearance_AppCompat_Menu = 2131362020;
 			
-			// aapt resource value: 0x7f0900fa
-			public const int TextAppearance_AppCompat_SearchResult_Subtitle = 2131296506;
+			// aapt resource value: 0x7f0a00e5
+			public const int TextAppearance_AppCompat_SearchResult_Subtitle = 2131362021;
 			
-			// aapt resource value: 0x7f0900fb
-			public const int TextAppearance_AppCompat_SearchResult_Title = 2131296507;
+			// aapt resource value: 0x7f0a00e6
+			public const int TextAppearance_AppCompat_SearchResult_Title = 2131362022;
 			
-			// aapt resource value: 0x7f0900fc
-			public const int TextAppearance_AppCompat_Small = 2131296508;
+			// aapt resource value: 0x7f0a00e7
+			public const int TextAppearance_AppCompat_Small = 2131362023;
 			
-			// aapt resource value: 0x7f0900fd
-			public const int TextAppearance_AppCompat_Small_Inverse = 2131296509;
+			// aapt resource value: 0x7f0a00e8
+			public const int TextAppearance_AppCompat_Small_Inverse = 2131362024;
 			
-			// aapt resource value: 0x7f0900fe
-			public const int TextAppearance_AppCompat_Subhead = 2131296510;
+			// aapt resource value: 0x7f0a00e9
+			public const int TextAppearance_AppCompat_Subhead = 2131362025;
 			
-			// aapt resource value: 0x7f0900ff
-			public const int TextAppearance_AppCompat_Subhead_Inverse = 2131296511;
+			// aapt resource value: 0x7f0a00ea
+			public const int TextAppearance_AppCompat_Subhead_Inverse = 2131362026;
 			
-			// aapt resource value: 0x7f090100
-			public const int TextAppearance_AppCompat_Title = 2131296512;
+			// aapt resource value: 0x7f0a00eb
+			public const int TextAppearance_AppCompat_Title = 2131362027;
 			
-			// aapt resource value: 0x7f090101
-			public const int TextAppearance_AppCompat_Title_Inverse = 2131296513;
+			// aapt resource value: 0x7f0a00ec
+			public const int TextAppearance_AppCompat_Title_Inverse = 2131362028;
 			
-			// aapt resource value: 0x7f090102
-			public const int TextAppearance_AppCompat_Widget_ActionBar_Menu = 2131296514;
+			// aapt resource value: 0x7f0a00ed
+			public const int TextAppearance_AppCompat_Widget_ActionBar_Menu = 2131362029;
 			
-			// aapt resource value: 0x7f090103
-			public const int TextAppearance_AppCompat_Widget_ActionBar_Subtitle = 2131296515;
+			// aapt resource value: 0x7f0a00ee
+			public const int TextAppearance_AppCompat_Widget_ActionBar_Subtitle = 2131362030;
 			
-			// aapt resource value: 0x7f090104
-			public const int TextAppearance_AppCompat_Widget_ActionBar_Subtitle_Inverse = 2131296516;
+			// aapt resource value: 0x7f0a00ef
+			public const int TextAppearance_AppCompat_Widget_ActionBar_Subtitle_Inverse = 2131362031;
 			
-			// aapt resource value: 0x7f090105
-			public const int TextAppearance_AppCompat_Widget_ActionBar_Title = 2131296517;
+			// aapt resource value: 0x7f0a00f0
+			public const int TextAppearance_AppCompat_Widget_ActionBar_Title = 2131362032;
 			
-			// aapt resource value: 0x7f090106
-			public const int TextAppearance_AppCompat_Widget_ActionBar_Title_Inverse = 2131296518;
+			// aapt resource value: 0x7f0a00f1
+			public const int TextAppearance_AppCompat_Widget_ActionBar_Title_Inverse = 2131362033;
 			
-			// aapt resource value: 0x7f090107
-			public const int TextAppearance_AppCompat_Widget_ActionMode_Subtitle = 2131296519;
+			// aapt resource value: 0x7f0a00f2
+			public const int TextAppearance_AppCompat_Widget_ActionMode_Subtitle = 2131362034;
 			
-			// aapt resource value: 0x7f090108
-			public const int TextAppearance_AppCompat_Widget_ActionMode_Subtitle_Inverse = 2131296520;
+			// aapt resource value: 0x7f0a00f3
+			public const int TextAppearance_AppCompat_Widget_ActionMode_Subtitle_Inverse = 2131362035;
 			
-			// aapt resource value: 0x7f090109
-			public const int TextAppearance_AppCompat_Widget_ActionMode_Title = 2131296521;
+			// aapt resource value: 0x7f0a00f4
+			public const int TextAppearance_AppCompat_Widget_ActionMode_Title = 2131362036;
 			
-			// aapt resource value: 0x7f09010a
-			public const int TextAppearance_AppCompat_Widget_ActionMode_Title_Inverse = 2131296522;
+			// aapt resource value: 0x7f0a00f5
+			public const int TextAppearance_AppCompat_Widget_ActionMode_Title_Inverse = 2131362037;
 			
-			// aapt resource value: 0x7f09010b
-			public const int TextAppearance_AppCompat_Widget_Button = 2131296523;
+			// aapt resource value: 0x7f0a00f6
+			public const int TextAppearance_AppCompat_Widget_Button = 2131362038;
 			
-			// aapt resource value: 0x7f09010c
-			public const int TextAppearance_AppCompat_Widget_Button_Inverse = 2131296524;
+			// aapt resource value: 0x7f0a00f7
+			public const int TextAppearance_AppCompat_Widget_Button_Inverse = 2131362039;
 			
-			// aapt resource value: 0x7f09010d
-			public const int TextAppearance_AppCompat_Widget_DropDownItem = 2131296525;
+			// aapt resource value: 0x7f0a00f8
+			public const int TextAppearance_AppCompat_Widget_DropDownItem = 2131362040;
 			
-			// aapt resource value: 0x7f09010e
-			public const int TextAppearance_AppCompat_Widget_PopupMenu_Large = 2131296526;
+			// aapt resource value: 0x7f0a00f9
+			public const int TextAppearance_AppCompat_Widget_PopupMenu_Large = 2131362041;
 			
-			// aapt resource value: 0x7f09010f
-			public const int TextAppearance_AppCompat_Widget_PopupMenu_Small = 2131296527;
+			// aapt resource value: 0x7f0a00fa
+			public const int TextAppearance_AppCompat_Widget_PopupMenu_Small = 2131362042;
 			
-			// aapt resource value: 0x7f090110
-			public const int TextAppearance_AppCompat_Widget_Switch = 2131296528;
+			// aapt resource value: 0x7f0a00fb
+			public const int TextAppearance_AppCompat_Widget_Switch = 2131362043;
 			
-			// aapt resource value: 0x7f090111
-			public const int TextAppearance_AppCompat_Widget_TextView_SpinnerItem = 2131296529;
+			// aapt resource value: 0x7f0a00fc
+			public const int TextAppearance_AppCompat_Widget_TextView_SpinnerItem = 2131362044;
 			
-			// aapt resource value: 0x7f09001a
-			public const int TextAppearance_Design_CollapsingToolbar_Expanded = 2131296282;
+			// aapt resource value: 0x7f0a015c
+			public const int TextAppearance_Design_CollapsingToolbar_Expanded = 2131362140;
 			
-			// aapt resource value: 0x7f09001b
-			public const int TextAppearance_Design_Counter = 2131296283;
+			// aapt resource value: 0x7f0a015d
+			public const int TextAppearance_Design_Counter = 2131362141;
 			
-			// aapt resource value: 0x7f09001c
-			public const int TextAppearance_Design_Counter_Overflow = 2131296284;
+			// aapt resource value: 0x7f0a015e
+			public const int TextAppearance_Design_Counter_Overflow = 2131362142;
 			
-			// aapt resource value: 0x7f09001d
-			public const int TextAppearance_Design_Error = 2131296285;
+			// aapt resource value: 0x7f0a015f
+			public const int TextAppearance_Design_Error = 2131362143;
 			
-			// aapt resource value: 0x7f09001e
-			public const int TextAppearance_Design_Hint = 2131296286;
+			// aapt resource value: 0x7f0a0160
+			public const int TextAppearance_Design_Hint = 2131362144;
 			
-			// aapt resource value: 0x7f09001f
-			public const int TextAppearance_Design_Snackbar_Message = 2131296287;
+			// aapt resource value: 0x7f0a0161
+			public const int TextAppearance_Design_Snackbar_Message = 2131362145;
 			
-			// aapt resource value: 0x7f090020
-			public const int TextAppearance_Design_Tab = 2131296288;
+			// aapt resource value: 0x7f0a0162
+			public const int TextAppearance_Design_Tab = 2131362146;
 			
-			// aapt resource value: 0x7f090053
-			public const int TextAppearance_StatusBar_EventContent = 2131296339;
+			// aapt resource value: 0x7f0a003e
+			public const int TextAppearance_StatusBar_EventContent = 2131361854;
 			
-			// aapt resource value: 0x7f090054
-			public const int TextAppearance_StatusBar_EventContent_Info = 2131296340;
+			// aapt resource value: 0x7f0a003f
+			public const int TextAppearance_StatusBar_EventContent_Info = 2131361855;
 			
-			// aapt resource value: 0x7f090055
-			public const int TextAppearance_StatusBar_EventContent_Line2 = 2131296341;
+			// aapt resource value: 0x7f0a0040
+			public const int TextAppearance_StatusBar_EventContent_Line2 = 2131361856;
 			
-			// aapt resource value: 0x7f090056
-			public const int TextAppearance_StatusBar_EventContent_Time = 2131296342;
+			// aapt resource value: 0x7f0a0041
+			public const int TextAppearance_StatusBar_EventContent_Time = 2131361857;
 			
-			// aapt resource value: 0x7f090057
-			public const int TextAppearance_StatusBar_EventContent_Title = 2131296343;
+			// aapt resource value: 0x7f0a0042
+			public const int TextAppearance_StatusBar_EventContent_Title = 2131361858;
 			
-			// aapt resource value: 0x7f090112
-			public const int TextAppearance_Widget_AppCompat_ExpandedMenu_Item = 2131296530;
+			// aapt resource value: 0x7f0a00fd
+			public const int TextAppearance_Widget_AppCompat_ExpandedMenu_Item = 2131362045;
 			
-			// aapt resource value: 0x7f090113
-			public const int TextAppearance_Widget_AppCompat_Toolbar_Subtitle = 2131296531;
+			// aapt resource value: 0x7f0a00fe
+			public const int TextAppearance_Widget_AppCompat_Toolbar_Subtitle = 2131362046;
 			
-			// aapt resource value: 0x7f090114
-			public const int TextAppearance_Widget_AppCompat_Toolbar_Title = 2131296532;
+			// aapt resource value: 0x7f0a00ff
+			public const int TextAppearance_Widget_AppCompat_Toolbar_Title = 2131362047;
 			
-			// aapt resource value: 0x7f090115
-			public const int Theme_AppCompat = 2131296533;
+			// aapt resource value: 0x7f0a0100
+			public const int Theme_AppCompat = 2131362048;
 			
-			// aapt resource value: 0x7f090116
-			public const int Theme_AppCompat_CompactMenu = 2131296534;
+			// aapt resource value: 0x7f0a0101
+			public const int Theme_AppCompat_CompactMenu = 2131362049;
 			
-			// aapt resource value: 0x7f090034
-			public const int Theme_AppCompat_DayNight = 2131296308;
+			// aapt resource value: 0x7f0a001f
+			public const int Theme_AppCompat_DayNight = 2131361823;
 			
-			// aapt resource value: 0x7f090035
-			public const int Theme_AppCompat_DayNight_DarkActionBar = 2131296309;
+			// aapt resource value: 0x7f0a0020
+			public const int Theme_AppCompat_DayNight_DarkActionBar = 2131361824;
 			
-			// aapt resource value: 0x7f090036
-			public const int Theme_AppCompat_DayNight_Dialog = 2131296310;
+			// aapt resource value: 0x7f0a0021
+			public const int Theme_AppCompat_DayNight_Dialog = 2131361825;
 			
-			// aapt resource value: 0x7f090037
-			public const int Theme_AppCompat_DayNight_Dialog_Alert = 2131296311;
+			// aapt resource value: 0x7f0a0022
+			public const int Theme_AppCompat_DayNight_Dialog_Alert = 2131361826;
 			
-			// aapt resource value: 0x7f090038
-			public const int Theme_AppCompat_DayNight_Dialog_MinWidth = 2131296312;
+			// aapt resource value: 0x7f0a0023
+			public const int Theme_AppCompat_DayNight_Dialog_MinWidth = 2131361827;
 			
-			// aapt resource value: 0x7f090039
-			public const int Theme_AppCompat_DayNight_DialogWhenLarge = 2131296313;
+			// aapt resource value: 0x7f0a0024
+			public const int Theme_AppCompat_DayNight_DialogWhenLarge = 2131361828;
 			
-			// aapt resource value: 0x7f09003a
-			public const int Theme_AppCompat_DayNight_NoActionBar = 2131296314;
+			// aapt resource value: 0x7f0a0025
+			public const int Theme_AppCompat_DayNight_NoActionBar = 2131361829;
 			
-			// aapt resource value: 0x7f090117
-			public const int Theme_AppCompat_Dialog = 2131296535;
+			// aapt resource value: 0x7f0a0102
+			public const int Theme_AppCompat_Dialog = 2131362050;
 			
-			// aapt resource value: 0x7f090118
-			public const int Theme_AppCompat_Dialog_Alert = 2131296536;
+			// aapt resource value: 0x7f0a0103
+			public const int Theme_AppCompat_Dialog_Alert = 2131362051;
 			
-			// aapt resource value: 0x7f090119
-			public const int Theme_AppCompat_Dialog_MinWidth = 2131296537;
+			// aapt resource value: 0x7f0a0104
+			public const int Theme_AppCompat_Dialog_MinWidth = 2131362052;
 			
-			// aapt resource value: 0x7f09011a
-			public const int Theme_AppCompat_DialogWhenLarge = 2131296538;
+			// aapt resource value: 0x7f0a0105
+			public const int Theme_AppCompat_DialogWhenLarge = 2131362053;
 			
-			// aapt resource value: 0x7f09011b
-			public const int Theme_AppCompat_Light = 2131296539;
+			// aapt resource value: 0x7f0a0106
+			public const int Theme_AppCompat_Light = 2131362054;
 			
-			// aapt resource value: 0x7f09011c
-			public const int Theme_AppCompat_Light_DarkActionBar = 2131296540;
+			// aapt resource value: 0x7f0a0107
+			public const int Theme_AppCompat_Light_DarkActionBar = 2131362055;
 			
-			// aapt resource value: 0x7f09011d
-			public const int Theme_AppCompat_Light_Dialog = 2131296541;
+			// aapt resource value: 0x7f0a0108
+			public const int Theme_AppCompat_Light_Dialog = 2131362056;
 			
-			// aapt resource value: 0x7f09011e
-			public const int Theme_AppCompat_Light_Dialog_Alert = 2131296542;
+			// aapt resource value: 0x7f0a0109
+			public const int Theme_AppCompat_Light_Dialog_Alert = 2131362057;
 			
-			// aapt resource value: 0x7f09011f
-			public const int Theme_AppCompat_Light_Dialog_MinWidth = 2131296543;
+			// aapt resource value: 0x7f0a010a
+			public const int Theme_AppCompat_Light_Dialog_MinWidth = 2131362058;
 			
-			// aapt resource value: 0x7f090120
-			public const int Theme_AppCompat_Light_DialogWhenLarge = 2131296544;
+			// aapt resource value: 0x7f0a010b
+			public const int Theme_AppCompat_Light_DialogWhenLarge = 2131362059;
 			
-			// aapt resource value: 0x7f090121
-			public const int Theme_AppCompat_Light_NoActionBar = 2131296545;
+			// aapt resource value: 0x7f0a010c
+			public const int Theme_AppCompat_Light_NoActionBar = 2131362060;
 			
-			// aapt resource value: 0x7f090122
-			public const int Theme_AppCompat_NoActionBar = 2131296546;
+			// aapt resource value: 0x7f0a010d
+			public const int Theme_AppCompat_NoActionBar = 2131362061;
 			
-			// aapt resource value: 0x7f090021
-			public const int Theme_Design = 2131296289;
+			// aapt resource value: 0x7f0a0163
+			public const int Theme_Design = 2131362147;
 			
-			// aapt resource value: 0x7f090022
-			public const int Theme_Design_BottomSheetDialog = 2131296290;
+			// aapt resource value: 0x7f0a0164
+			public const int Theme_Design_BottomSheetDialog = 2131362148;
 			
-			// aapt resource value: 0x7f090023
-			public const int Theme_Design_Light = 2131296291;
+			// aapt resource value: 0x7f0a0165
+			public const int Theme_Design_Light = 2131362149;
 			
-			// aapt resource value: 0x7f090024
-			public const int Theme_Design_Light_BottomSheetDialog = 2131296292;
+			// aapt resource value: 0x7f0a0166
+			public const int Theme_Design_Light_BottomSheetDialog = 2131362150;
 			
-			// aapt resource value: 0x7f090025
-			public const int Theme_Design_Light_NoActionBar = 2131296293;
+			// aapt resource value: 0x7f0a0167
+			public const int Theme_Design_Light_NoActionBar = 2131362151;
 			
-			// aapt resource value: 0x7f090026
-			public const int Theme_Design_NoActionBar = 2131296294;
+			// aapt resource value: 0x7f0a0168
+			public const int Theme_Design_NoActionBar = 2131362152;
 			
-			// aapt resource value: 0x7f090000
-			public const int Theme_MediaRouter = 2131296256;
+			// aapt resource value: 0x7f0a0000
+			public const int Theme_MediaRouter = 2131361792;
 			
-			// aapt resource value: 0x7f090001
-			public const int Theme_MediaRouter_Light = 2131296257;
+			// aapt resource value: 0x7f0a0001
+			public const int Theme_MediaRouter_Light = 2131361793;
 			
-			// aapt resource value: 0x7f090002
-			public const int Theme_MediaRouter_Light_DarkControlPanel = 2131296258;
+			// aapt resource value: 0x7f0a0002
+			public const int Theme_MediaRouter_Light_DarkControlPanel = 2131361794;
 			
-			// aapt resource value: 0x7f090003
-			public const int Theme_MediaRouter_LightControlPanel = 2131296259;
+			// aapt resource value: 0x7f0a0003
+			public const int Theme_MediaRouter_LightControlPanel = 2131361795;
 			
-			// aapt resource value: 0x7f090123
-			public const int ThemeOverlay_AppCompat = 2131296547;
+			// aapt resource value: 0x7f0a010e
+			public const int ThemeOverlay_AppCompat = 2131362062;
 			
-			// aapt resource value: 0x7f090124
-			public const int ThemeOverlay_AppCompat_ActionBar = 2131296548;
+			// aapt resource value: 0x7f0a010f
+			public const int ThemeOverlay_AppCompat_ActionBar = 2131362063;
 			
-			// aapt resource value: 0x7f090125
-			public const int ThemeOverlay_AppCompat_Dark = 2131296549;
+			// aapt resource value: 0x7f0a0110
+			public const int ThemeOverlay_AppCompat_Dark = 2131362064;
 			
-			// aapt resource value: 0x7f090126
-			public const int ThemeOverlay_AppCompat_Dark_ActionBar = 2131296550;
+			// aapt resource value: 0x7f0a0111
+			public const int ThemeOverlay_AppCompat_Dark_ActionBar = 2131362065;
 			
-			// aapt resource value: 0x7f090127
-			public const int ThemeOverlay_AppCompat_Light = 2131296551;
+			// aapt resource value: 0x7f0a0112
+			public const int ThemeOverlay_AppCompat_Light = 2131362066;
 			
-			// aapt resource value: 0x7f090128
-			public const int Widget_AppCompat_ActionBar = 2131296552;
+			// aapt resource value: 0x7f0a0113
+			public const int Widget_AppCompat_ActionBar = 2131362067;
 			
-			// aapt resource value: 0x7f090129
-			public const int Widget_AppCompat_ActionBar_Solid = 2131296553;
+			// aapt resource value: 0x7f0a0114
+			public const int Widget_AppCompat_ActionBar_Solid = 2131362068;
 			
-			// aapt resource value: 0x7f09012a
-			public const int Widget_AppCompat_ActionBar_TabBar = 2131296554;
+			// aapt resource value: 0x7f0a0115
+			public const int Widget_AppCompat_ActionBar_TabBar = 2131362069;
 			
-			// aapt resource value: 0x7f09012b
-			public const int Widget_AppCompat_ActionBar_TabText = 2131296555;
+			// aapt resource value: 0x7f0a0116
+			public const int Widget_AppCompat_ActionBar_TabText = 2131362070;
 			
-			// aapt resource value: 0x7f09012c
-			public const int Widget_AppCompat_ActionBar_TabView = 2131296556;
+			// aapt resource value: 0x7f0a0117
+			public const int Widget_AppCompat_ActionBar_TabView = 2131362071;
 			
-			// aapt resource value: 0x7f09012d
-			public const int Widget_AppCompat_ActionButton = 2131296557;
+			// aapt resource value: 0x7f0a0118
+			public const int Widget_AppCompat_ActionButton = 2131362072;
 			
-			// aapt resource value: 0x7f09012e
-			public const int Widget_AppCompat_ActionButton_CloseMode = 2131296558;
+			// aapt resource value: 0x7f0a0119
+			public const int Widget_AppCompat_ActionButton_CloseMode = 2131362073;
 			
-			// aapt resource value: 0x7f09012f
-			public const int Widget_AppCompat_ActionButton_Overflow = 2131296559;
+			// aapt resource value: 0x7f0a011a
+			public const int Widget_AppCompat_ActionButton_Overflow = 2131362074;
 			
-			// aapt resource value: 0x7f090130
-			public const int Widget_AppCompat_ActionMode = 2131296560;
+			// aapt resource value: 0x7f0a011b
+			public const int Widget_AppCompat_ActionMode = 2131362075;
 			
-			// aapt resource value: 0x7f090131
-			public const int Widget_AppCompat_ActivityChooserView = 2131296561;
+			// aapt resource value: 0x7f0a011c
+			public const int Widget_AppCompat_ActivityChooserView = 2131362076;
 			
-			// aapt resource value: 0x7f090132
-			public const int Widget_AppCompat_AutoCompleteTextView = 2131296562;
+			// aapt resource value: 0x7f0a011d
+			public const int Widget_AppCompat_AutoCompleteTextView = 2131362077;
 			
-			// aapt resource value: 0x7f090133
-			public const int Widget_AppCompat_Button = 2131296563;
+			// aapt resource value: 0x7f0a011e
+			public const int Widget_AppCompat_Button = 2131362078;
 			
-			// aapt resource value: 0x7f090134
-			public const int Widget_AppCompat_Button_Borderless = 2131296564;
+			// aapt resource value: 0x7f0a011f
+			public const int Widget_AppCompat_Button_Borderless = 2131362079;
 			
-			// aapt resource value: 0x7f090135
-			public const int Widget_AppCompat_Button_Borderless_Colored = 2131296565;
+			// aapt resource value: 0x7f0a0120
+			public const int Widget_AppCompat_Button_Borderless_Colored = 2131362080;
 			
-			// aapt resource value: 0x7f090136
-			public const int Widget_AppCompat_Button_ButtonBar_AlertDialog = 2131296566;
+			// aapt resource value: 0x7f0a0121
+			public const int Widget_AppCompat_Button_ButtonBar_AlertDialog = 2131362081;
 			
-			// aapt resource value: 0x7f090137
-			public const int Widget_AppCompat_Button_Colored = 2131296567;
+			// aapt resource value: 0x7f0a0122
+			public const int Widget_AppCompat_Button_Colored = 2131362082;
 			
-			// aapt resource value: 0x7f090138
-			public const int Widget_AppCompat_Button_Small = 2131296568;
+			// aapt resource value: 0x7f0a0123
+			public const int Widget_AppCompat_Button_Small = 2131362083;
 			
-			// aapt resource value: 0x7f090139
-			public const int Widget_AppCompat_ButtonBar = 2131296569;
+			// aapt resource value: 0x7f0a0124
+			public const int Widget_AppCompat_ButtonBar = 2131362084;
 			
-			// aapt resource value: 0x7f09013a
-			public const int Widget_AppCompat_ButtonBar_AlertDialog = 2131296570;
+			// aapt resource value: 0x7f0a0125
+			public const int Widget_AppCompat_ButtonBar_AlertDialog = 2131362085;
 			
-			// aapt resource value: 0x7f09013b
-			public const int Widget_AppCompat_CompoundButton_CheckBox = 2131296571;
+			// aapt resource value: 0x7f0a0126
+			public const int Widget_AppCompat_CompoundButton_CheckBox = 2131362086;
 			
-			// aapt resource value: 0x7f09013c
-			public const int Widget_AppCompat_CompoundButton_RadioButton = 2131296572;
+			// aapt resource value: 0x7f0a0127
+			public const int Widget_AppCompat_CompoundButton_RadioButton = 2131362087;
 			
-			// aapt resource value: 0x7f09013d
-			public const int Widget_AppCompat_CompoundButton_Switch = 2131296573;
+			// aapt resource value: 0x7f0a0128
+			public const int Widget_AppCompat_CompoundButton_Switch = 2131362088;
 			
-			// aapt resource value: 0x7f09013e
-			public const int Widget_AppCompat_DrawerArrowToggle = 2131296574;
+			// aapt resource value: 0x7f0a0129
+			public const int Widget_AppCompat_DrawerArrowToggle = 2131362089;
 			
-			// aapt resource value: 0x7f09013f
-			public const int Widget_AppCompat_DropDownItem_Spinner = 2131296575;
+			// aapt resource value: 0x7f0a012a
+			public const int Widget_AppCompat_DropDownItem_Spinner = 2131362090;
 			
-			// aapt resource value: 0x7f090140
-			public const int Widget_AppCompat_EditText = 2131296576;
+			// aapt resource value: 0x7f0a012b
+			public const int Widget_AppCompat_EditText = 2131362091;
 			
-			// aapt resource value: 0x7f090141
-			public const int Widget_AppCompat_ImageButton = 2131296577;
+			// aapt resource value: 0x7f0a012c
+			public const int Widget_AppCompat_ImageButton = 2131362092;
 			
-			// aapt resource value: 0x7f090142
-			public const int Widget_AppCompat_Light_ActionBar = 2131296578;
+			// aapt resource value: 0x7f0a012d
+			public const int Widget_AppCompat_Light_ActionBar = 2131362093;
 			
-			// aapt resource value: 0x7f090143
-			public const int Widget_AppCompat_Light_ActionBar_Solid = 2131296579;
+			// aapt resource value: 0x7f0a012e
+			public const int Widget_AppCompat_Light_ActionBar_Solid = 2131362094;
 			
-			// aapt resource value: 0x7f090144
-			public const int Widget_AppCompat_Light_ActionBar_Solid_Inverse = 2131296580;
+			// aapt resource value: 0x7f0a012f
+			public const int Widget_AppCompat_Light_ActionBar_Solid_Inverse = 2131362095;
 			
-			// aapt resource value: 0x7f090145
-			public const int Widget_AppCompat_Light_ActionBar_TabBar = 2131296581;
+			// aapt resource value: 0x7f0a0130
+			public const int Widget_AppCompat_Light_ActionBar_TabBar = 2131362096;
 			
-			// aapt resource value: 0x7f090146
-			public const int Widget_AppCompat_Light_ActionBar_TabBar_Inverse = 2131296582;
+			// aapt resource value: 0x7f0a0131
+			public const int Widget_AppCompat_Light_ActionBar_TabBar_Inverse = 2131362097;
 			
-			// aapt resource value: 0x7f090147
-			public const int Widget_AppCompat_Light_ActionBar_TabText = 2131296583;
+			// aapt resource value: 0x7f0a0132
+			public const int Widget_AppCompat_Light_ActionBar_TabText = 2131362098;
 			
-			// aapt resource value: 0x7f090148
-			public const int Widget_AppCompat_Light_ActionBar_TabText_Inverse = 2131296584;
+			// aapt resource value: 0x7f0a0133
+			public const int Widget_AppCompat_Light_ActionBar_TabText_Inverse = 2131362099;
 			
-			// aapt resource value: 0x7f090149
-			public const int Widget_AppCompat_Light_ActionBar_TabView = 2131296585;
+			// aapt resource value: 0x7f0a0134
+			public const int Widget_AppCompat_Light_ActionBar_TabView = 2131362100;
 			
-			// aapt resource value: 0x7f09014a
-			public const int Widget_AppCompat_Light_ActionBar_TabView_Inverse = 2131296586;
+			// aapt resource value: 0x7f0a0135
+			public const int Widget_AppCompat_Light_ActionBar_TabView_Inverse = 2131362101;
 			
-			// aapt resource value: 0x7f09014b
-			public const int Widget_AppCompat_Light_ActionButton = 2131296587;
+			// aapt resource value: 0x7f0a0136
+			public const int Widget_AppCompat_Light_ActionButton = 2131362102;
 			
-			// aapt resource value: 0x7f09014c
-			public const int Widget_AppCompat_Light_ActionButton_CloseMode = 2131296588;
+			// aapt resource value: 0x7f0a0137
+			public const int Widget_AppCompat_Light_ActionButton_CloseMode = 2131362103;
 			
-			// aapt resource value: 0x7f09014d
-			public const int Widget_AppCompat_Light_ActionButton_Overflow = 2131296589;
+			// aapt resource value: 0x7f0a0138
+			public const int Widget_AppCompat_Light_ActionButton_Overflow = 2131362104;
 			
-			// aapt resource value: 0x7f09014e
-			public const int Widget_AppCompat_Light_ActionMode_Inverse = 2131296590;
+			// aapt resource value: 0x7f0a0139
+			public const int Widget_AppCompat_Light_ActionMode_Inverse = 2131362105;
 			
-			// aapt resource value: 0x7f09014f
-			public const int Widget_AppCompat_Light_ActivityChooserView = 2131296591;
+			// aapt resource value: 0x7f0a013a
+			public const int Widget_AppCompat_Light_ActivityChooserView = 2131362106;
 			
-			// aapt resource value: 0x7f090150
-			public const int Widget_AppCompat_Light_AutoCompleteTextView = 2131296592;
+			// aapt resource value: 0x7f0a013b
+			public const int Widget_AppCompat_Light_AutoCompleteTextView = 2131362107;
 			
-			// aapt resource value: 0x7f090151
-			public const int Widget_AppCompat_Light_DropDownItem_Spinner = 2131296593;
+			// aapt resource value: 0x7f0a013c
+			public const int Widget_AppCompat_Light_DropDownItem_Spinner = 2131362108;
 			
-			// aapt resource value: 0x7f090152
-			public const int Widget_AppCompat_Light_ListPopupWindow = 2131296594;
+			// aapt resource value: 0x7f0a013d
+			public const int Widget_AppCompat_Light_ListPopupWindow = 2131362109;
 			
-			// aapt resource value: 0x7f090153
-			public const int Widget_AppCompat_Light_ListView_DropDown = 2131296595;
+			// aapt resource value: 0x7f0a013e
+			public const int Widget_AppCompat_Light_ListView_DropDown = 2131362110;
 			
-			// aapt resource value: 0x7f090154
-			public const int Widget_AppCompat_Light_PopupMenu = 2131296596;
+			// aapt resource value: 0x7f0a013f
+			public const int Widget_AppCompat_Light_PopupMenu = 2131362111;
 			
-			// aapt resource value: 0x7f090155
-			public const int Widget_AppCompat_Light_PopupMenu_Overflow = 2131296597;
+			// aapt resource value: 0x7f0a0140
+			public const int Widget_AppCompat_Light_PopupMenu_Overflow = 2131362112;
 			
-			// aapt resource value: 0x7f090156
-			public const int Widget_AppCompat_Light_SearchView = 2131296598;
+			// aapt resource value: 0x7f0a0141
+			public const int Widget_AppCompat_Light_SearchView = 2131362113;
 			
-			// aapt resource value: 0x7f090157
-			public const int Widget_AppCompat_Light_Spinner_DropDown_ActionBar = 2131296599;
+			// aapt resource value: 0x7f0a0142
+			public const int Widget_AppCompat_Light_Spinner_DropDown_ActionBar = 2131362114;
 			
-			// aapt resource value: 0x7f090158
-			public const int Widget_AppCompat_ListPopupWindow = 2131296600;
+			// aapt resource value: 0x7f0a0143
+			public const int Widget_AppCompat_ListPopupWindow = 2131362115;
 			
-			// aapt resource value: 0x7f090159
-			public const int Widget_AppCompat_ListView = 2131296601;
+			// aapt resource value: 0x7f0a0144
+			public const int Widget_AppCompat_ListView = 2131362116;
 			
-			// aapt resource value: 0x7f09015a
-			public const int Widget_AppCompat_ListView_DropDown = 2131296602;
+			// aapt resource value: 0x7f0a0145
+			public const int Widget_AppCompat_ListView_DropDown = 2131362117;
 			
-			// aapt resource value: 0x7f09015b
-			public const int Widget_AppCompat_ListView_Menu = 2131296603;
+			// aapt resource value: 0x7f0a0146
+			public const int Widget_AppCompat_ListView_Menu = 2131362118;
 			
-			// aapt resource value: 0x7f09015c
-			public const int Widget_AppCompat_PopupMenu = 2131296604;
+			// aapt resource value: 0x7f0a0147
+			public const int Widget_AppCompat_PopupMenu = 2131362119;
 			
-			// aapt resource value: 0x7f09015d
-			public const int Widget_AppCompat_PopupMenu_Overflow = 2131296605;
+			// aapt resource value: 0x7f0a0148
+			public const int Widget_AppCompat_PopupMenu_Overflow = 2131362120;
 			
-			// aapt resource value: 0x7f09015e
-			public const int Widget_AppCompat_PopupWindow = 2131296606;
+			// aapt resource value: 0x7f0a0149
+			public const int Widget_AppCompat_PopupWindow = 2131362121;
 			
-			// aapt resource value: 0x7f09015f
-			public const int Widget_AppCompat_ProgressBar = 2131296607;
+			// aapt resource value: 0x7f0a014a
+			public const int Widget_AppCompat_ProgressBar = 2131362122;
 			
-			// aapt resource value: 0x7f090160
-			public const int Widget_AppCompat_ProgressBar_Horizontal = 2131296608;
+			// aapt resource value: 0x7f0a014b
+			public const int Widget_AppCompat_ProgressBar_Horizontal = 2131362123;
 			
-			// aapt resource value: 0x7f090161
-			public const int Widget_AppCompat_RatingBar = 2131296609;
+			// aapt resource value: 0x7f0a014c
+			public const int Widget_AppCompat_RatingBar = 2131362124;
 			
-			// aapt resource value: 0x7f090162
-			public const int Widget_AppCompat_RatingBar_Indicator = 2131296610;
+			// aapt resource value: 0x7f0a014d
+			public const int Widget_AppCompat_RatingBar_Indicator = 2131362125;
 			
-			// aapt resource value: 0x7f090163
-			public const int Widget_AppCompat_RatingBar_Small = 2131296611;
+			// aapt resource value: 0x7f0a014e
+			public const int Widget_AppCompat_RatingBar_Small = 2131362126;
 			
-			// aapt resource value: 0x7f090164
-			public const int Widget_AppCompat_SearchView = 2131296612;
+			// aapt resource value: 0x7f0a014f
+			public const int Widget_AppCompat_SearchView = 2131362127;
 			
-			// aapt resource value: 0x7f090165
-			public const int Widget_AppCompat_SearchView_ActionBar = 2131296613;
+			// aapt resource value: 0x7f0a0150
+			public const int Widget_AppCompat_SearchView_ActionBar = 2131362128;
 			
-			// aapt resource value: 0x7f090166
-			public const int Widget_AppCompat_SeekBar = 2131296614;
+			// aapt resource value: 0x7f0a0151
+			public const int Widget_AppCompat_SeekBar = 2131362129;
 			
-			// aapt resource value: 0x7f090167
-			public const int Widget_AppCompat_Spinner = 2131296615;
+			// aapt resource value: 0x7f0a0152
+			public const int Widget_AppCompat_Spinner = 2131362130;
 			
-			// aapt resource value: 0x7f090168
-			public const int Widget_AppCompat_Spinner_DropDown = 2131296616;
+			// aapt resource value: 0x7f0a0153
+			public const int Widget_AppCompat_Spinner_DropDown = 2131362131;
 			
-			// aapt resource value: 0x7f090169
-			public const int Widget_AppCompat_Spinner_DropDown_ActionBar = 2131296617;
+			// aapt resource value: 0x7f0a0154
+			public const int Widget_AppCompat_Spinner_DropDown_ActionBar = 2131362132;
 			
-			// aapt resource value: 0x7f09016a
-			public const int Widget_AppCompat_Spinner_Underlined = 2131296618;
+			// aapt resource value: 0x7f0a0155
+			public const int Widget_AppCompat_Spinner_Underlined = 2131362133;
 			
-			// aapt resource value: 0x7f09016b
-			public const int Widget_AppCompat_TextView_SpinnerItem = 2131296619;
+			// aapt resource value: 0x7f0a0156
+			public const int Widget_AppCompat_TextView_SpinnerItem = 2131362134;
 			
-			// aapt resource value: 0x7f09016c
-			public const int Widget_AppCompat_Toolbar = 2131296620;
+			// aapt resource value: 0x7f0a0157
+			public const int Widget_AppCompat_Toolbar = 2131362135;
 			
-			// aapt resource value: 0x7f09016d
-			public const int Widget_AppCompat_Toolbar_Button_Navigation = 2131296621;
+			// aapt resource value: 0x7f0a0158
+			public const int Widget_AppCompat_Toolbar_Button_Navigation = 2131362136;
 			
-			// aapt resource value: 0x7f090027
-			public const int Widget_Design_AppBarLayout = 2131296295;
+			// aapt resource value: 0x7f0a0169
+			public const int Widget_Design_AppBarLayout = 2131362153;
 			
-			// aapt resource value: 0x7f090028
-			public const int Widget_Design_BottomSheet_Modal = 2131296296;
+			// aapt resource value: 0x7f0a016a
+			public const int Widget_Design_BottomSheet_Modal = 2131362154;
 			
-			// aapt resource value: 0x7f090029
-			public const int Widget_Design_CollapsingToolbar = 2131296297;
+			// aapt resource value: 0x7f0a016b
+			public const int Widget_Design_CollapsingToolbar = 2131362155;
 			
-			// aapt resource value: 0x7f09002a
-			public const int Widget_Design_CoordinatorLayout = 2131296298;
+			// aapt resource value: 0x7f0a016c
+			public const int Widget_Design_CoordinatorLayout = 2131362156;
 			
-			// aapt resource value: 0x7f09002b
-			public const int Widget_Design_FloatingActionButton = 2131296299;
+			// aapt resource value: 0x7f0a016d
+			public const int Widget_Design_FloatingActionButton = 2131362157;
 			
-			// aapt resource value: 0x7f09002c
-			public const int Widget_Design_NavigationView = 2131296300;
+			// aapt resource value: 0x7f0a016e
+			public const int Widget_Design_NavigationView = 2131362158;
 			
-			// aapt resource value: 0x7f09002d
-			public const int Widget_Design_ScrimInsetsFrameLayout = 2131296301;
+			// aapt resource value: 0x7f0a016f
+			public const int Widget_Design_ScrimInsetsFrameLayout = 2131362159;
 			
-			// aapt resource value: 0x7f09002e
-			public const int Widget_Design_Snackbar = 2131296302;
+			// aapt resource value: 0x7f0a0170
+			public const int Widget_Design_Snackbar = 2131362160;
 			
-			// aapt resource value: 0x7f090017
-			public const int Widget_Design_TabLayout = 2131296279;
+			// aapt resource value: 0x7f0a0159
+			public const int Widget_Design_TabLayout = 2131362137;
 			
-			// aapt resource value: 0x7f09002f
-			public const int Widget_Design_TextInputLayout = 2131296303;
+			// aapt resource value: 0x7f0a0171
+			public const int Widget_Design_TextInputLayout = 2131362161;
 			
-			// aapt resource value: 0x7f090004
-			public const int Widget_MediaRouter_ChooserText = 2131296260;
+			// aapt resource value: 0x7f0a0004
+			public const int Widget_MediaRouter_ChooserText = 2131361796;
 			
-			// aapt resource value: 0x7f090005
-			public const int Widget_MediaRouter_ChooserText_Primary = 2131296261;
+			// aapt resource value: 0x7f0a0005
+			public const int Widget_MediaRouter_ChooserText_Primary = 2131361797;
 			
-			// aapt resource value: 0x7f090006
-			public const int Widget_MediaRouter_ChooserText_Primary_Dark = 2131296262;
+			// aapt resource value: 0x7f0a0006
+			public const int Widget_MediaRouter_ChooserText_Primary_Dark = 2131361798;
 			
-			// aapt resource value: 0x7f090007
-			public const int Widget_MediaRouter_ChooserText_Primary_Light = 2131296263;
+			// aapt resource value: 0x7f0a0007
+			public const int Widget_MediaRouter_ChooserText_Primary_Light = 2131361799;
 			
-			// aapt resource value: 0x7f090008
-			public const int Widget_MediaRouter_ChooserText_Secondary = 2131296264;
+			// aapt resource value: 0x7f0a0008
+			public const int Widget_MediaRouter_ChooserText_Secondary = 2131361800;
 			
-			// aapt resource value: 0x7f090009
-			public const int Widget_MediaRouter_ChooserText_Secondary_Dark = 2131296265;
+			// aapt resource value: 0x7f0a0009
+			public const int Widget_MediaRouter_ChooserText_Secondary_Dark = 2131361801;
 			
-			// aapt resource value: 0x7f09000a
-			public const int Widget_MediaRouter_ChooserText_Secondary_Light = 2131296266;
+			// aapt resource value: 0x7f0a000a
+			public const int Widget_MediaRouter_ChooserText_Secondary_Light = 2131361802;
 			
-			// aapt resource value: 0x7f09000b
-			public const int Widget_MediaRouter_ControllerText = 2131296267;
+			// aapt resource value: 0x7f0a000b
+			public const int Widget_MediaRouter_ControllerText = 2131361803;
 			
-			// aapt resource value: 0x7f09000c
-			public const int Widget_MediaRouter_ControllerText_Primary = 2131296268;
+			// aapt resource value: 0x7f0a000c
+			public const int Widget_MediaRouter_ControllerText_Primary = 2131361804;
 			
-			// aapt resource value: 0x7f09000d
-			public const int Widget_MediaRouter_ControllerText_Primary_Dark = 2131296269;
+			// aapt resource value: 0x7f0a000d
+			public const int Widget_MediaRouter_ControllerText_Primary_Dark = 2131361805;
 			
-			// aapt resource value: 0x7f09000e
-			public const int Widget_MediaRouter_ControllerText_Primary_Light = 2131296270;
+			// aapt resource value: 0x7f0a000e
+			public const int Widget_MediaRouter_ControllerText_Primary_Light = 2131361806;
 			
-			// aapt resource value: 0x7f09000f
-			public const int Widget_MediaRouter_ControllerText_Secondary = 2131296271;
+			// aapt resource value: 0x7f0a000f
+			public const int Widget_MediaRouter_ControllerText_Secondary = 2131361807;
 			
-			// aapt resource value: 0x7f090010
-			public const int Widget_MediaRouter_ControllerText_Secondary_Dark = 2131296272;
+			// aapt resource value: 0x7f0a0010
+			public const int Widget_MediaRouter_ControllerText_Secondary_Dark = 2131361808;
 			
-			// aapt resource value: 0x7f090011
-			public const int Widget_MediaRouter_ControllerText_Secondary_Light = 2131296273;
+			// aapt resource value: 0x7f0a0011
+			public const int Widget_MediaRouter_ControllerText_Secondary_Light = 2131361809;
 			
-			// aapt resource value: 0x7f090012
-			public const int Widget_MediaRouter_ControllerText_Title = 2131296274;
+			// aapt resource value: 0x7f0a0012
+			public const int Widget_MediaRouter_ControllerText_Title = 2131361810;
 			
-			// aapt resource value: 0x7f090013
-			public const int Widget_MediaRouter_ControllerText_Title_Dark = 2131296275;
+			// aapt resource value: 0x7f0a0013
+			public const int Widget_MediaRouter_ControllerText_Title_Dark = 2131361811;
 			
-			// aapt resource value: 0x7f090014
-			public const int Widget_MediaRouter_ControllerText_Title_Light = 2131296276;
+			// aapt resource value: 0x7f0a0014
+			public const int Widget_MediaRouter_ControllerText_Title_Light = 2131361812;
 			
-			// aapt resource value: 0x7f090015
-			public const int Widget_MediaRouter_Light_MediaRouteButton = 2131296277;
+			// aapt resource value: 0x7f0a0015
+			public const int Widget_MediaRouter_Light_MediaRouteButton = 2131361813;
 			
-			// aapt resource value: 0x7f090016
-			public const int Widget_MediaRouter_MediaRouteButton = 2131296278;
+			// aapt resource value: 0x7f0a0016
+			public const int Widget_MediaRouter_MediaRouteButton = 2131361814;
 			
 			static Style()
 			{
@@ -4180,33 +4180,33 @@ namespace CustomLayouts.Droid
 			
 			public static int[] ActionBar = new int[]
 			{
-					2130772061,
-					2130772063,
-					2130772064,
-					2130772065,
-					2130772066,
-					2130772067,
-					2130772068,
-					2130772069,
-					2130772070,
-					2130772071,
-					2130772072,
-					2130772073,
-					2130772074,
-					2130772075,
-					2130772076,
-					2130772077,
-					2130772078,
-					2130772079,
-					2130772080,
-					2130772081,
-					2130772082,
-					2130772083,
-					2130772084,
-					2130772085,
-					2130772086,
-					2130772087,
-					2130772144};
+					2130772007,
+					2130772009,
+					2130772010,
+					2130772011,
+					2130772012,
+					2130772013,
+					2130772014,
+					2130772015,
+					2130772016,
+					2130772017,
+					2130772018,
+					2130772019,
+					2130772020,
+					2130772021,
+					2130772022,
+					2130772023,
+					2130772024,
+					2130772025,
+					2130772026,
+					2130772027,
+					2130772028,
+					2130772029,
+					2130772030,
+					2130772031,
+					2130772032,
+					2130772033,
+					2130772090};
 			
 			// aapt resource value: 10
 			public const int ActionBar_background = 10;
@@ -4307,12 +4307,12 @@ namespace CustomLayouts.Droid
 			
 			public static int[] ActionMode = new int[]
 			{
-					2130772061,
-					2130772067,
-					2130772068,
-					2130772072,
-					2130772074,
-					2130772088};
+					2130772007,
+					2130772013,
+					2130772014,
+					2130772018,
+					2130772020,
+					2130772034};
 			
 			// aapt resource value: 3
 			public const int ActionMode_background = 3;
@@ -4334,8 +4334,8 @@ namespace CustomLayouts.Droid
 			
 			public static int[] ActivityChooserView = new int[]
 			{
-					2130772089,
-					2130772090};
+					2130772035,
+					2130772036};
 			
 			// aapt resource value: 1
 			public const int ActivityChooserView_expandActivityOverflowButtonDrawable = 1;
@@ -4346,11 +4346,11 @@ namespace CustomLayouts.Droid
 			public static int[] AlertDialog = new int[]
 			{
 					16842994,
-					2130772091,
-					2130772092,
-					2130772093,
-					2130772094,
-					2130772095};
+					2130772037,
+					2130772038,
+					2130772039,
+					2130772040,
+					2130772041};
 			
 			// aapt resource value: 0
 			public const int AlertDialog_android_layout = 0;
@@ -4373,22 +4373,22 @@ namespace CustomLayouts.Droid
 			public static int[] AppBarLayout = new int[]
 			{
 					16842964,
-					2130771991,
-					2130772086};
+					2130772032,
+					2130772215};
 			
 			// aapt resource value: 0
 			public const int AppBarLayout_android_background = 0;
 			
-			// aapt resource value: 2
-			public const int AppBarLayout_elevation = 2;
-			
 			// aapt resource value: 1
-			public const int AppBarLayout_expanded = 1;
+			public const int AppBarLayout_elevation = 1;
+			
+			// aapt resource value: 2
+			public const int AppBarLayout_expanded = 2;
 			
 			public static int[] AppBarLayout_LayoutParams = new int[]
 			{
-					2130771992,
-					2130771993};
+					2130772216,
+					2130772217};
 			
 			// aapt resource value: 0
 			public const int AppBarLayout_LayoutParams_layout_scrollFlags = 0;
@@ -4399,7 +4399,7 @@ namespace CustomLayouts.Droid
 			public static int[] AppCompatImageView = new int[]
 			{
 					16843033,
-					2130772096};
+					2130772042};
 			
 			// aapt resource value: 0
 			public const int AppCompatImageView_android_src = 0;
@@ -4410,7 +4410,7 @@ namespace CustomLayouts.Droid
 			public static int[] AppCompatTextView = new int[]
 			{
 					16842804,
-					2130772097};
+					2130772043};
 			
 			// aapt resource value: 0
 			public const int AppCompatTextView_android_textAppearance = 0;
@@ -4422,6 +4422,60 @@ namespace CustomLayouts.Droid
 			{
 					16842839,
 					16842926,
+					2130772044,
+					2130772045,
+					2130772046,
+					2130772047,
+					2130772048,
+					2130772049,
+					2130772050,
+					2130772051,
+					2130772052,
+					2130772053,
+					2130772054,
+					2130772055,
+					2130772056,
+					2130772057,
+					2130772058,
+					2130772059,
+					2130772060,
+					2130772061,
+					2130772062,
+					2130772063,
+					2130772064,
+					2130772065,
+					2130772066,
+					2130772067,
+					2130772068,
+					2130772069,
+					2130772070,
+					2130772071,
+					2130772072,
+					2130772073,
+					2130772074,
+					2130772075,
+					2130772076,
+					2130772077,
+					2130772078,
+					2130772079,
+					2130772080,
+					2130772081,
+					2130772082,
+					2130772083,
+					2130772084,
+					2130772085,
+					2130772086,
+					2130772087,
+					2130772088,
+					2130772089,
+					2130772090,
+					2130772091,
+					2130772092,
+					2130772093,
+					2130772094,
+					2130772095,
+					2130772096,
+					2130772097,
 					2130772098,
 					2130772099,
 					2130772100,
@@ -4477,61 +4531,7 @@ namespace CustomLayouts.Droid
 					2130772150,
 					2130772151,
 					2130772152,
-					2130772153,
-					2130772154,
-					2130772155,
-					2130772156,
-					2130772157,
-					2130772158,
-					2130772159,
-					2130772160,
-					2130772161,
-					2130772162,
-					2130772163,
-					2130772164,
-					2130772165,
-					2130772166,
-					2130772167,
-					2130772168,
-					2130772169,
-					2130772170,
-					2130772171,
-					2130772172,
-					2130772173,
-					2130772174,
-					2130772175,
-					2130772176,
-					2130772177,
-					2130772178,
-					2130772179,
-					2130772180,
-					2130772181,
-					2130772182,
-					2130772183,
-					2130772184,
-					2130772185,
-					2130772186,
-					2130772187,
-					2130772188,
-					2130772189,
-					2130772190,
-					2130772191,
-					2130772192,
-					2130772193,
-					2130772194,
-					2130772195,
-					2130772196,
-					2130772197,
-					2130772198,
-					2130772199,
-					2130772200,
-					2130772201,
-					2130772202,
-					2130772203,
-					2130772204,
-					2130772205,
-					2130772206,
-					2130772207};
+					2130772153};
 			
 			// aapt resource value: 23
 			public const int AppCompatTheme_actionBarDivider = 23;
@@ -4871,8 +4871,8 @@ namespace CustomLayouts.Droid
 			
 			public static int[] BottomSheetBehavior_Params = new int[]
 			{
-					2130771994,
-					2130771995};
+					2130772218,
+					2130772219};
 			
 			// aapt resource value: 1
 			public const int BottomSheetBehavior_Params_behavior_hideable = 1;
@@ -4882,7 +4882,7 @@ namespace CustomLayouts.Droid
 			
 			public static int[] ButtonBarLayout = new int[]
 			{
-					2130772208};
+					2130772154};
 			
 			// aapt resource value: 0
 			public const int ButtonBarLayout_allowStacking = 0;
@@ -4891,17 +4891,17 @@ namespace CustomLayouts.Droid
 			{
 					16843071,
 					16843072,
-					2130772273,
-					2130772274,
-					2130772275,
-					2130772276,
-					2130772277,
-					2130772278,
-					2130772279,
-					2130772280,
-					2130772281,
-					2130772282,
-					2130772283};
+					2130771995,
+					2130771996,
+					2130771997,
+					2130771998,
+					2130771999,
+					2130772000,
+					2130772001,
+					2130772002,
+					2130772003,
+					2130772004,
+					2130772005};
 			
 			// aapt resource value: 1
 			public const int CardView_android_minHeight = 1;
@@ -4944,8 +4944,8 @@ namespace CustomLayouts.Droid
 			
 			public static int[] CollapsingAppBarLayout_LayoutParams = new int[]
 			{
-					2130771996,
-					2130771997};
+					2130772220,
+					2130772221};
 			
 			// aapt resource value: 0
 			public const int CollapsingAppBarLayout_LayoutParams_layout_collapseMode = 0;
@@ -4955,68 +4955,68 @@ namespace CustomLayouts.Droid
 			
 			public static int[] CollapsingToolbarLayout = new int[]
 			{
-					2130771998,
-					2130771999,
-					2130772000,
-					2130772001,
-					2130772002,
-					2130772003,
-					2130772004,
-					2130772005,
-					2130772006,
-					2130772007,
-					2130772008,
 					2130772009,
-					2130772010,
-					2130772063};
-			
-			// aapt resource value: 10
-			public const int CollapsingToolbarLayout_collapsedTitleGravity = 10;
-			
-			// aapt resource value: 6
-			public const int CollapsingToolbarLayout_collapsedTitleTextAppearance = 6;
-			
-			// aapt resource value: 7
-			public const int CollapsingToolbarLayout_contentScrim = 7;
+					2130772222,
+					2130772223,
+					2130772224,
+					2130772225,
+					2130772226,
+					2130772227,
+					2130772228,
+					2130772229,
+					2130772230,
+					2130772231,
+					2130772232,
+					2130772233,
+					2130772234};
 			
 			// aapt resource value: 11
-			public const int CollapsingToolbarLayout_expandedTitleGravity = 11;
+			public const int CollapsingToolbarLayout_collapsedTitleGravity = 11;
 			
-			// aapt resource value: 0
-			public const int CollapsingToolbarLayout_expandedTitleMargin = 0;
-			
-			// aapt resource value: 4
-			public const int CollapsingToolbarLayout_expandedTitleMarginBottom = 4;
-			
-			// aapt resource value: 3
-			public const int CollapsingToolbarLayout_expandedTitleMarginEnd = 3;
-			
-			// aapt resource value: 1
-			public const int CollapsingToolbarLayout_expandedTitleMarginStart = 1;
-			
-			// aapt resource value: 2
-			public const int CollapsingToolbarLayout_expandedTitleMarginTop = 2;
-			
-			// aapt resource value: 5
-			public const int CollapsingToolbarLayout_expandedTitleTextAppearance = 5;
+			// aapt resource value: 7
+			public const int CollapsingToolbarLayout_collapsedTitleTextAppearance = 7;
 			
 			// aapt resource value: 8
-			public const int CollapsingToolbarLayout_statusBarScrim = 8;
-			
-			// aapt resource value: 13
-			public const int CollapsingToolbarLayout_title = 13;
+			public const int CollapsingToolbarLayout_contentScrim = 8;
 			
 			// aapt resource value: 12
-			public const int CollapsingToolbarLayout_titleEnabled = 12;
+			public const int CollapsingToolbarLayout_expandedTitleGravity = 12;
+			
+			// aapt resource value: 1
+			public const int CollapsingToolbarLayout_expandedTitleMargin = 1;
+			
+			// aapt resource value: 5
+			public const int CollapsingToolbarLayout_expandedTitleMarginBottom = 5;
+			
+			// aapt resource value: 4
+			public const int CollapsingToolbarLayout_expandedTitleMarginEnd = 4;
+			
+			// aapt resource value: 2
+			public const int CollapsingToolbarLayout_expandedTitleMarginStart = 2;
+			
+			// aapt resource value: 3
+			public const int CollapsingToolbarLayout_expandedTitleMarginTop = 3;
+			
+			// aapt resource value: 6
+			public const int CollapsingToolbarLayout_expandedTitleTextAppearance = 6;
 			
 			// aapt resource value: 9
-			public const int CollapsingToolbarLayout_toolbarId = 9;
+			public const int CollapsingToolbarLayout_statusBarScrim = 9;
+			
+			// aapt resource value: 0
+			public const int CollapsingToolbarLayout_title = 0;
+			
+			// aapt resource value: 13
+			public const int CollapsingToolbarLayout_titleEnabled = 13;
+			
+			// aapt resource value: 10
+			public const int CollapsingToolbarLayout_toolbarId = 10;
 			
 			public static int[] CompoundButton = new int[]
 			{
 					16843015,
-					2130772209,
-					2130772210};
+					2130772155,
+					2130772156};
 			
 			// aapt resource value: 0
 			public const int CompoundButton_android_button = 0;
@@ -5029,8 +5029,8 @@ namespace CustomLayouts.Droid
 			
 			public static int[] CoordinatorLayout = new int[]
 			{
-					2130772011,
-					2130772012};
+					2130772235,
+					2130772236};
 			
 			// aapt resource value: 0
 			public const int CoordinatorLayout_keylines = 0;
@@ -5041,10 +5041,10 @@ namespace CustomLayouts.Droid
 			public static int[] CoordinatorLayout_LayoutParams = new int[]
 			{
 					16842931,
-					2130772013,
-					2130772014,
-					2130772015,
-					2130772016};
+					2130772237,
+					2130772238,
+					2130772239,
+					2130772240};
 			
 			// aapt resource value: 0
 			public const int CoordinatorLayout_LayoutParams_android_layout_gravity = 0;
@@ -5063,9 +5063,9 @@ namespace CustomLayouts.Droid
 			
 			public static int[] DesignTheme = new int[]
 			{
-					2130772017,
-					2130772018,
-					2130772019};
+					2130772241,
+					2130772242,
+					2130772243};
 			
 			// aapt resource value: 0
 			public const int DesignTheme_bottomSheetDialogTheme = 0;
@@ -5078,14 +5078,14 @@ namespace CustomLayouts.Droid
 			
 			public static int[] DrawerArrowToggle = new int[]
 			{
-					2130772211,
-					2130772212,
-					2130772213,
-					2130772214,
-					2130772215,
-					2130772216,
-					2130772217,
-					2130772218};
+					2130772157,
+					2130772158,
+					2130772159,
+					2130772160,
+					2130772161,
+					2130772162,
+					2130772163,
+					2130772164};
 			
 			// aapt resource value: 4
 			public const int DrawerArrowToggle_arrowHeadLength = 4;
@@ -5113,44 +5113,44 @@ namespace CustomLayouts.Droid
 			
 			public static int[] FloatingActionButton = new int[]
 			{
-					2130772020,
-					2130772021,
-					2130772022,
-					2130772023,
-					2130772024,
-					2130772086,
-					2130772267,
-					2130772268};
-			
-			// aapt resource value: 6
-			public const int FloatingActionButton_backgroundTint = 6;
-			
-			// aapt resource value: 7
-			public const int FloatingActionButton_backgroundTintMode = 7;
-			
-			// aapt resource value: 3
-			public const int FloatingActionButton_borderWidth = 3;
-			
-			// aapt resource value: 5
-			public const int FloatingActionButton_elevation = 5;
+					2130772032,
+					2130772213,
+					2130772214,
+					2130772244,
+					2130772245,
+					2130772246,
+					2130772247,
+					2130772248};
 			
 			// aapt resource value: 1
-			public const int FloatingActionButton_fabSize = 1;
+			public const int FloatingActionButton_backgroundTint = 1;
 			
 			// aapt resource value: 2
-			public const int FloatingActionButton_pressedTranslationZ = 2;
+			public const int FloatingActionButton_backgroundTintMode = 2;
+			
+			// aapt resource value: 6
+			public const int FloatingActionButton_borderWidth = 6;
 			
 			// aapt resource value: 0
-			public const int FloatingActionButton_rippleColor = 0;
+			public const int FloatingActionButton_elevation = 0;
 			
 			// aapt resource value: 4
-			public const int FloatingActionButton_useCompatPadding = 4;
+			public const int FloatingActionButton_fabSize = 4;
+			
+			// aapt resource value: 5
+			public const int FloatingActionButton_pressedTranslationZ = 5;
+			
+			// aapt resource value: 3
+			public const int FloatingActionButton_rippleColor = 3;
+			
+			// aapt resource value: 7
+			public const int FloatingActionButton_useCompatPadding = 7;
 			
 			public static int[] ForegroundLinearLayout = new int[]
 			{
 					16843017,
 					16843264,
-					2130772025};
+					2130772249};
 			
 			// aapt resource value: 0
 			public const int ForegroundLinearLayout_android_foreground = 0;
@@ -5168,10 +5168,10 @@ namespace CustomLayouts.Droid
 					16843046,
 					16843047,
 					16843048,
-					2130772071,
-					2130772219,
-					2130772220,
-					2130772221};
+					2130772017,
+					2130772165,
+					2130772166,
+					2130772167};
 			
 			// aapt resource value: 2
 			public const int LinearLayoutCompat_android_baselineAligned = 2;
@@ -5234,7 +5234,7 @@ namespace CustomLayouts.Droid
 			{
 					16843071,
 					16843072,
-					2130771990};
+					2130771994};
 			
 			// aapt resource value: 1
 			public const int MediaRouteButton_android_minHeight = 1;
@@ -5287,10 +5287,10 @@ namespace CustomLayouts.Droid
 					16843236,
 					16843237,
 					16843375,
-					2130772222,
-					2130772223,
-					2130772224,
-					2130772225};
+					2130772168,
+					2130772169,
+					2130772170,
+					2130772171};
 			
 			// aapt resource value: 14
 			public const int MenuItem_actionLayout = 14;
@@ -5352,7 +5352,7 @@ namespace CustomLayouts.Droid
 					16843055,
 					16843056,
 					16843057,
-					2130772226};
+					2130772172};
 			
 			// aapt resource value: 4
 			public const int MenuView_android_headerBackground = 4;
@@ -5383,13 +5383,13 @@ namespace CustomLayouts.Droid
 					16842964,
 					16842973,
 					16843039,
-					2130772026,
-					2130772027,
-					2130772028,
-					2130772029,
-					2130772030,
-					2130772031,
-					2130772086};
+					2130772032,
+					2130772250,
+					2130772251,
+					2130772252,
+					2130772253,
+					2130772254,
+					2130772255};
 			
 			// aapt resource value: 0
 			public const int NavigationView_android_background = 0;
@@ -5400,31 +5400,31 @@ namespace CustomLayouts.Droid
 			// aapt resource value: 2
 			public const int NavigationView_android_maxWidth = 2;
 			
+			// aapt resource value: 3
+			public const int NavigationView_elevation = 3;
+			
 			// aapt resource value: 9
-			public const int NavigationView_elevation = 9;
-			
-			// aapt resource value: 8
-			public const int NavigationView_headerLayout = 8;
-			
-			// aapt resource value: 6
-			public const int NavigationView_itemBackground = 6;
-			
-			// aapt resource value: 4
-			public const int NavigationView_itemIconTint = 4;
+			public const int NavigationView_headerLayout = 9;
 			
 			// aapt resource value: 7
-			public const int NavigationView_itemTextAppearance = 7;
+			public const int NavigationView_itemBackground = 7;
 			
 			// aapt resource value: 5
-			public const int NavigationView_itemTextColor = 5;
+			public const int NavigationView_itemIconTint = 5;
 			
-			// aapt resource value: 3
-			public const int NavigationView_menu = 3;
+			// aapt resource value: 8
+			public const int NavigationView_itemTextAppearance = 8;
+			
+			// aapt resource value: 6
+			public const int NavigationView_itemTextColor = 6;
+			
+			// aapt resource value: 4
+			public const int NavigationView_menu = 4;
 			
 			public static int[] PopupWindow = new int[]
 			{
 					16843126,
-					2130772227};
+					2130772173};
 			
 			// aapt resource value: 0
 			public const int PopupWindow_android_popupBackground = 0;
@@ -5434,7 +5434,7 @@ namespace CustomLayouts.Droid
 			
 			public static int[] PopupWindowBackgroundState = new int[]
 			{
-					2130772228};
+					2130772174};
 			
 			// aapt resource value: 0
 			public const int PopupWindowBackgroundState_state_above_anchor = 0;
@@ -5442,10 +5442,10 @@ namespace CustomLayouts.Droid
 			public static int[] RecyclerView = new int[]
 			{
 					16842948,
-					2130772269,
-					2130772270,
-					2130772271,
-					2130772272};
+					2130771968,
+					2130771969,
+					2130771970,
+					2130771971};
 			
 			// aapt resource value: 0
 			public const int RecyclerView_android_orientation = 0;
@@ -5464,14 +5464,14 @@ namespace CustomLayouts.Droid
 			
 			public static int[] ScrimInsetsFrameLayout = new int[]
 			{
-					2130772032};
+					2130772256};
 			
 			// aapt resource value: 0
 			public const int ScrimInsetsFrameLayout_insetForeground = 0;
 			
 			public static int[] ScrollingViewBehavior_Params = new int[]
 			{
-					2130772033};
+					2130772257};
 			
 			// aapt resource value: 0
 			public const int ScrollingViewBehavior_Params_behavior_overlapTop = 0;
@@ -5482,19 +5482,19 @@ namespace CustomLayouts.Droid
 					16843039,
 					16843296,
 					16843364,
-					2130772229,
-					2130772230,
-					2130772231,
-					2130772232,
-					2130772233,
-					2130772234,
-					2130772235,
-					2130772236,
-					2130772237,
-					2130772238,
-					2130772239,
-					2130772240,
-					2130772241};
+					2130772175,
+					2130772176,
+					2130772177,
+					2130772178,
+					2130772179,
+					2130772180,
+					2130772181,
+					2130772182,
+					2130772183,
+					2130772184,
+					2130772185,
+					2130772186,
+					2130772187};
 			
 			// aapt resource value: 0
 			public const int SearchView_android_focusable = 0;
@@ -5550,17 +5550,17 @@ namespace CustomLayouts.Droid
 			public static int[] SnackbarLayout = new int[]
 			{
 					16843039,
-					2130772034,
-					2130772086};
+					2130772032,
+					2130772258};
 			
 			// aapt resource value: 0
 			public const int SnackbarLayout_android_maxWidth = 0;
 			
-			// aapt resource value: 2
-			public const int SnackbarLayout_elevation = 2;
-			
 			// aapt resource value: 1
-			public const int SnackbarLayout_maxActionInlineWidth = 1;
+			public const int SnackbarLayout_elevation = 1;
+			
+			// aapt resource value: 2
+			public const int SnackbarLayout_maxActionInlineWidth = 2;
 			
 			public static int[] Spinner = new int[]
 			{
@@ -5568,7 +5568,7 @@ namespace CustomLayouts.Droid
 					16843126,
 					16843131,
 					16843362,
-					2130772087};
+					2130772033};
 			
 			// aapt resource value: 3
 			public const int Spinner_android_dropDownWidth = 3;
@@ -5590,13 +5590,13 @@ namespace CustomLayouts.Droid
 					16843044,
 					16843045,
 					16843074,
-					2130772242,
-					2130772243,
-					2130772244,
-					2130772245,
-					2130772246,
-					2130772247,
-					2130772248};
+					2130772188,
+					2130772189,
+					2130772190,
+					2130772191,
+					2130772192,
+					2130772193,
+					2130772194};
 			
 			// aapt resource value: 1
 			public const int SwitchCompat_android_textOff = 1;
@@ -5645,22 +5645,22 @@ namespace CustomLayouts.Droid
 			
 			public static int[] TabLayout = new int[]
 			{
-					2130772035,
-					2130772036,
-					2130772037,
-					2130772038,
-					2130772039,
-					2130772040,
-					2130772041,
-					2130772042,
-					2130772043,
-					2130772044,
-					2130772045,
-					2130772046,
-					2130772047,
-					2130772048,
-					2130772049,
-					2130772050};
+					2130772259,
+					2130772260,
+					2130772261,
+					2130772262,
+					2130772263,
+					2130772264,
+					2130772265,
+					2130772266,
+					2130772267,
+					2130772268,
+					2130772269,
+					2130772270,
+					2130772271,
+					2130772272,
+					2130772273,
+					2130772274};
 			
 			// aapt resource value: 3
 			public const int TabLayout_tabBackground = 3;
@@ -5720,7 +5720,7 @@ namespace CustomLayouts.Droid
 					16843106,
 					16843107,
 					16843108,
-					2130772097};
+					2130772043};
 			
 			// aapt resource value: 4
 			public const int TextAppearance_android_shadowColor = 4;
@@ -5753,15 +5753,15 @@ namespace CustomLayouts.Droid
 			{
 					16842906,
 					16843088,
-					2130772051,
-					2130772052,
-					2130772053,
-					2130772054,
-					2130772055,
-					2130772056,
-					2130772057,
-					2130772058,
-					2130772059};
+					2130772275,
+					2130772276,
+					2130772277,
+					2130772278,
+					2130772279,
+					2130772280,
+					2130772281,
+					2130772282,
+					2130772283};
 			
 			// aapt resource value: 1
 			public const int TextInputLayout_android_hint = 1;
@@ -5800,29 +5800,29 @@ namespace CustomLayouts.Droid
 			{
 					16842927,
 					16843072,
-					2130772063,
-					2130772066,
-					2130772070,
-					2130772082,
-					2130772083,
-					2130772084,
-					2130772085,
-					2130772087,
-					2130772249,
-					2130772250,
-					2130772251,
-					2130772252,
-					2130772253,
-					2130772254,
-					2130772255,
-					2130772256,
-					2130772257,
-					2130772258,
-					2130772259,
-					2130772260,
-					2130772261,
-					2130772262,
-					2130772263};
+					2130772009,
+					2130772012,
+					2130772016,
+					2130772028,
+					2130772029,
+					2130772030,
+					2130772031,
+					2130772033,
+					2130772195,
+					2130772196,
+					2130772197,
+					2130772198,
+					2130772199,
+					2130772200,
+					2130772201,
+					2130772202,
+					2130772203,
+					2130772204,
+					2130772205,
+					2130772206,
+					2130772207,
+					2130772208,
+					2130772209};
 			
 			// aapt resource value: 0
 			public const int Toolbar_android_gravity = 0;
@@ -5903,9 +5903,9 @@ namespace CustomLayouts.Droid
 			{
 					16842752,
 					16842970,
-					2130772264,
-					2130772265,
-					2130772266};
+					2130772210,
+					2130772211,
+					2130772212};
 			
 			// aapt resource value: 1
 			public const int View_android_focusable = 1;
@@ -5925,8 +5925,8 @@ namespace CustomLayouts.Droid
 			public static int[] ViewBackgroundHelper = new int[]
 			{
 					16842964,
-					2130772267,
-					2130772268};
+					2130772213,
+					2130772214};
 			
 			// aapt resource value: 0
 			public const int ViewBackgroundHelper_android_background = 0;

--- a/src/Droid/packages.config
+++ b/src/Droid/packages.config
@@ -8,5 +8,5 @@
   <package id="Xamarin.Android.Support.v7.MediaRouter" version="23.3.0" targetFramework="monoandroid6.0.99" />
   <package id="Xamarin.Android.Support.v7.RecyclerView" version="23.3.0" targetFramework="monoandroid6.0.99" />
   <package id="Xamarin.Android.Support.Vector.Drawable" version="23.3.0" targetFramework="monoandroid6.0.99" />
-  <package id="Xamarin.Forms" version="2.2.0.31" targetFramework="monoandroid6.0.99" />
+  <package id="Xamarin.Forms" version="2.3.4.231" targetFramework="monoandroid71" />
 </packages>

--- a/src/iOS/CustomLayouts.iOS.csproj
+++ b/src/iOS/CustomLayouts.iOS.csproj
@@ -19,7 +19,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
-    <MtouchArch>i386</MtouchArch>
+    <MtouchArch>x86_64</MtouchArch>
     <MtouchLink>SdkOnly</MtouchLink>
     <MtouchDebug>true</MtouchDebug>
     <MtouchProfiling>true</MtouchProfiling>
@@ -41,7 +41,7 @@
     <OutputPath>bin\iPhoneSimulator\Release</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <MtouchArch>i386</MtouchArch>
+    <MtouchArch>x86_64</MtouchArch>
     <ConsolePause>false</ConsolePause>
     <MtouchLink>None</MtouchLink>
   </PropertyGroup>
@@ -66,16 +66,16 @@
     <Reference Include="System.Core" />
     <Reference Include="Xamarin.iOS" />
     <Reference Include="Xamarin.Forms.Core">
-      <HintPath>..\packages\Xamarin.Forms.2.2.0.31\lib\Xamarin.iOS10\Xamarin.Forms.Core.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.2.3.4.231\lib\Xamarin.iOS10\Xamarin.Forms.Core.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Platform">
-      <HintPath>..\packages\Xamarin.Forms.2.2.0.31\lib\Xamarin.iOS10\Xamarin.Forms.Platform.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.2.3.4.231\lib\Xamarin.iOS10\Xamarin.Forms.Platform.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Platform.iOS">
-      <HintPath>..\packages\Xamarin.Forms.2.2.0.31\lib\Xamarin.iOS10\Xamarin.Forms.Platform.iOS.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.2.3.4.231\lib\Xamarin.iOS10\Xamarin.Forms.Platform.iOS.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Xaml">
-      <HintPath>..\packages\Xamarin.Forms.2.2.0.31\lib\Xamarin.iOS10\Xamarin.Forms.Xaml.dll</HintPath>
+      <HintPath>..\packages\Xamarin.Forms.2.3.4.231\lib\Xamarin.iOS10\Xamarin.Forms.Xaml.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -116,8 +116,8 @@
   </ItemGroup>
   <Import Project="..\CustomLayouts\CustomLayouts.projitems" Label="Shared" Condition="Exists('..\CustomLayouts\CustomLayouts.projitems')" />
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
-  <Import Project="..\packages\Xamarin.Forms.2.2.0.31\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets" Condition="Exists('..\packages\Xamarin.Forms.2.2.0.31\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets')" />
   <ItemGroup>
     <Folder Include="Renderers\" />
   </ItemGroup>
+  <Import Project="..\packages\Xamarin.Forms.2.3.4.231\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets" Condition="Exists('..\packages\Xamarin.Forms.2.3.4.231\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets')" />
 </Project>

--- a/src/iOS/packages.config
+++ b/src/iOS/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Xamarin.Forms" version="2.2.0.31" targetFramework="xamarinios10" />
+  <package id="Xamarin.Forms" version="2.3.4.231" targetFramework="xamarinios10" />
 </packages>


### PR DESCRIPTION
Replaced `Device.OnPlatform` with `Device.RuntimePlatform`, because `OnPlatform` is deprecated in Xamarin.Forms 2.3.4

Set the Android TargetFrameworkVersion to Automatic

Set the iOS Simulator Build to x86_64 because iOS deprecated the i386
architecture in iOS10